### PR TITLE
Correction on heap size and pin numbers

### DIFF
--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
@@ -174,7 +174,7 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf TRUE)
 ###################################################
 # the size of the CLR managed heap is defined here
 ###################################################
-set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x400")
+set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x1000")
 set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x1800")
 
 # generate output files

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/README.md
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/README.md
@@ -1,6 +1,8 @@
 ## Another community board ##
 
-The board used in this community contribution is a STM32F411CEU6 based board from IngenuityMicro called Electron. The board has only 8 pins of which 3 are already used for 3.3V, 5V and GND, leaving use of only 7 pins. These pins can be used for:
+The board used in this community contribution is a STM32F411CEU6 based board from IngenuityMicro called Electron. The board has only 12 pins of which 3 are already used for 3.3V, 5V and GND, leaving use of only 9 pins.
+
+These pins can be used for:
 
 - 1 x TX/RX (Serial is not tested yet (January 3rd, 2018))
 - 4 x PWM


### PR DESCRIPTION
The heap size is corrected for 1 of 4 of the community boards for NanoBooter.
Pins numbers weren't matched the board in readme.md

- Fixes nanoFramework/Home#556

Signed-off-by: piwi1263 <piwi1263@gmail.com>
  
  