### PR TITLE
Support for serial communication

### DIFF
--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
@@ -41,6 +41,11 @@ if(USE_NETWORKING_OPTION)
     find_package(CHIBIOS_LWIP REQUIRED)
 endif()
 
+# nF feature: filesystem
+if(USE_FILESYSTEM_OPTION)
+    find_package(CHIBIOS_FATFS REQUIRED)
+endif()
+
 #######################################
 
 
@@ -100,6 +105,9 @@ add_executable(
 
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
+        # sources for target specifc stuff related with APIs
+    # Windows.Devices.SerialCommunication
+    "target_windows_devices_serialcommunication_config.cpp"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/board.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/board.h
@@ -111,16 +111,16 @@
 #define GPIOB_PIN14                 14U
 #define GPIOB_PIN15                 15U
 
-#define GPIOC_ARD_A5                0U
-#define GPIOC_ADC1_IN10             0U
-#define GPIOC_ARD_A4                1U
-#define GPIOC_ADC1_IN11             1U
+#define GPIOC_PIN0                  0U
+//#define GPIOC_ADC1_IN10             0U
+#define GPIOC_PIN1                  1U
+//#define GPIOC_ADC1_IN11             1U
 #define GPIOC_PIN2                  2U
 #define GPIOC_PIN3                  3U
 #define GPIOC_PIN4                  4U
 #define GPIOC_PIN5                  5U
-#define GPIOC_PIN6                  6U
-#define GPIOC_ARD_D9                7U
+#define GPIOC_USART6_TX             6U
+#define GPIOC_USART6_RX             7U
 #define GPIOC_PIN8                  8U
 #define GPIOC_PIN9                  9U
 #define GPIOC_PIN10                 10U
@@ -533,8 +533,8 @@
  * PC3  - PIN3                      (input pullup).
  * PC4  - PIN4                      (input pullup).
  * PC5  - PIN5                      (input pullup).
- * PC6  - PIN6                      (input pullup).
- * PC7  - ARD_D9                    (input pullup).
+ * PC6  - PIN6 = TX6                (Alternate8 floating).
+ * PC7  - PIN7 = RX6                (Alternate8 floating).
  * PC8  - PIN8                      (input pullup).
  * PC9  - PIN9                      (input pullup).
  * PC10 - PIN10                     (input pullup).
@@ -544,14 +544,14 @@
  * PC14 - OSC32_IN                  (input floating).
  * PC15 - OSC32_OUT                 (input floating).
  */
-#define VAL_GPIOC_MODER             (PIN_MODE_INPUT(GPIOC_ARD_A5) |         \
-                                     PIN_MODE_INPUT(GPIOC_ARD_A4) |         \
+#define VAL_GPIOC_MODER             (PIN_MODE_INPUT(GPIOC_PIN0) |         \
+                                     PIN_MODE_INPUT(GPIOC_PIN1) |         \
                                      PIN_MODE_INPUT(GPIOC_PIN2) |           \
                                      PIN_MODE_INPUT(GPIOC_PIN3) |           \
                                      PIN_MODE_INPUT(GPIOC_PIN4) |           \
                                      PIN_MODE_INPUT(GPIOC_PIN5) |           \
-                                     PIN_MODE_INPUT(GPIOC_PIN6) |           \
-                                     PIN_MODE_INPUT(GPIOC_ARD_D9) |         \
+                                     PIN_MODE_ALTERNATE(GPIOC_USART6_TX) |           \
+                                     PIN_MODE_ALTERNATE(GPIOC_USART6_RX) |         \
                                      PIN_MODE_INPUT(GPIOC_PIN8) |           \
                                      PIN_MODE_INPUT(GPIOC_PIN9) |           \
                                      PIN_MODE_INPUT(GPIOC_PIN10) |          \
@@ -560,14 +560,14 @@
                                      PIN_MODE_INPUT(GPIOC_BUTTON) |         \
                                      PIN_MODE_INPUT(GPIOC_OSC32_IN) |       \
                                      PIN_MODE_INPUT(GPIOC_OSC32_OUT))
-#define VAL_GPIOC_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOC_ARD_A5) |     \
-                                     PIN_OTYPE_PUSHPULL(GPIOC_ARD_A4) |     \
+#define VAL_GPIOC_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOC_PIN0) |     \
+                                     PIN_OTYPE_PUSHPULL(GPIOC_PIN1) |     \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN2) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN3) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN4) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN5) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOC_PIN6) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOC_ARD_D9) |     \
+                                     PIN_OTYPE_PUSHPULL(GPIOC_USART6_TX) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOC_USART6_RX) |     \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN8) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN9) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN10) |      \
@@ -576,14 +576,14 @@
                                      PIN_OTYPE_PUSHPULL(GPIOC_BUTTON) |     \
                                      PIN_OTYPE_PUSHPULL(GPIOC_OSC32_IN) |   \
                                      PIN_OTYPE_PUSHPULL(GPIOC_OSC32_OUT))
-#define VAL_GPIOC_OSPEEDR           (PIN_OSPEED_HIGH(GPIOC_ARD_A5) |        \
-                                     PIN_OSPEED_HIGH(GPIOC_ARD_A4) |        \
+#define VAL_GPIOC_OSPEEDR           (PIN_OSPEED_HIGH(GPIOC_PIN0) |        \
+                                     PIN_OSPEED_HIGH(GPIOC_PIN1) |        \
                                      PIN_OSPEED_HIGH(GPIOC_PIN2) |          \
                                      PIN_OSPEED_HIGH(GPIOC_PIN3) |          \
                                      PIN_OSPEED_HIGH(GPIOC_PIN4) |          \
                                      PIN_OSPEED_HIGH(GPIOC_PIN5) |          \
-                                     PIN_OSPEED_HIGH(GPIOC_PIN6) |          \
-                                     PIN_OSPEED_HIGH(GPIOC_ARD_D9) |        \
+                                     PIN_OSPEED_MEDIUM(GPIOC_USART6_TX) |          \
+                                     PIN_OSPEED_MEDIUM(GPIOC_USART6_RX) |        \
                                      PIN_OSPEED_HIGH(GPIOC_PIN8) |          \
                                      PIN_OSPEED_HIGH(GPIOC_PIN9) |          \
                                      PIN_OSPEED_HIGH(GPIOC_PIN10) |         \
@@ -592,14 +592,14 @@
                                      PIN_OSPEED_HIGH(GPIOC_BUTTON) |        \
                                      PIN_OSPEED_HIGH(GPIOC_OSC32_IN) |      \
                                      PIN_OSPEED_HIGH(GPIOC_OSC32_OUT))
-#define VAL_GPIOC_PUPDR             (PIN_PUPDR_PULLUP(GPIOC_ARD_A5) |       \
-                                     PIN_PUPDR_PULLUP(GPIOC_ARD_A4) |       \
+#define VAL_GPIOC_PUPDR             (PIN_PUPDR_PULLUP(GPIOC_PIN0) |       \
+                                     PIN_PUPDR_PULLUP(GPIOC_PIN1) |       \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN2) |         \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN3) |         \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN4) |         \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN5) |         \
-                                     PIN_PUPDR_PULLUP(GPIOC_PIN6) |         \
-                                     PIN_PUPDR_PULLUP(GPIOC_ARD_D9) |       \
+                                     PIN_PUPDR_FLOATING(GPIOC_USART6_TX) |         \
+                                     PIN_PUPDR_FLOATING(GPIOC_USART6_RX) |       \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN8) |         \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN9) |         \
                                      PIN_PUPDR_PULLUP(GPIOC_PIN10) |        \
@@ -608,14 +608,14 @@
                                      PIN_PUPDR_FLOATING(GPIOC_BUTTON) |     \
                                      PIN_PUPDR_FLOATING(GPIOC_OSC32_IN) |   \
                                      PIN_PUPDR_FLOATING(GPIOC_OSC32_OUT))
-#define VAL_GPIOC_ODR               (PIN_ODR_HIGH(GPIOC_ARD_A5) |           \
-                                     PIN_ODR_HIGH(GPIOC_ARD_A4) |           \
+#define VAL_GPIOC_ODR               (PIN_ODR_HIGH(GPIOC_PIN0) |           \
+                                     PIN_ODR_HIGH(GPIOC_PIN1) |           \
                                      PIN_ODR_HIGH(GPIOC_PIN2) |             \
                                      PIN_ODR_HIGH(GPIOC_PIN3) |             \
                                      PIN_ODR_HIGH(GPIOC_PIN4) |             \
                                      PIN_ODR_HIGH(GPIOC_PIN5) |             \
-                                     PIN_ODR_HIGH(GPIOC_PIN6) |             \
-                                     PIN_ODR_HIGH(GPIOC_ARD_D9) |           \
+                                     PIN_ODR_HIGH(GPIOC_USART6_TX) |             \
+                                     PIN_ODR_HIGH(GPIOC_USART6_RX) |           \
                                      PIN_ODR_HIGH(GPIOC_PIN8) |             \
                                      PIN_ODR_HIGH(GPIOC_PIN9) |             \
                                      PIN_ODR_HIGH(GPIOC_PIN10) |            \
@@ -624,14 +624,14 @@
                                      PIN_ODR_HIGH(GPIOC_BUTTON) |           \
                                      PIN_ODR_HIGH(GPIOC_OSC32_IN) |         \
                                      PIN_ODR_HIGH(GPIOC_OSC32_OUT))
-#define VAL_GPIOC_AFRL              (PIN_AFIO_AF(GPIOC_ARD_A5, 0U) |        \
-                                     PIN_AFIO_AF(GPIOC_ARD_A4, 0U) |        \
+#define VAL_GPIOC_AFRL              (PIN_AFIO_AF(GPIOC_PIN0, 0U) |        \
+                                     PIN_AFIO_AF(GPIOC_PIN1, 0U) |        \
                                      PIN_AFIO_AF(GPIOC_PIN2, 0U) |          \
                                      PIN_AFIO_AF(GPIOC_PIN3, 0U) |          \
                                      PIN_AFIO_AF(GPIOC_PIN4, 0U) |          \
                                      PIN_AFIO_AF(GPIOC_PIN5, 0U) |          \
-                                     PIN_AFIO_AF(GPIOC_PIN6, 0U) |          \
-                                     PIN_AFIO_AF(GPIOC_ARD_D9, 0U))
+                                     PIN_AFIO_AF(GPIOC_USART6_TX, 8U) |          \
+                                     PIN_AFIO_AF(GPIOC_USART6_RX, 8U))
 #define VAL_GPIOC_AFRH              (PIN_AFIO_AF(GPIOC_PIN8, 0U) |          \
                                      PIN_AFIO_AF(GPIOC_PIN9, 0U) |          \
                                      PIN_AFIO_AF(GPIOC_PIN10, 0U) |         \

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/board.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/board.h
@@ -319,8 +319,8 @@
                                      PIN_MODE_INPUT(GPIOA_ARD_D12) |        \
                                      PIN_MODE_INPUT(GPIOA_ARD_D11) |        \
                                      PIN_MODE_INPUT(GPIOA_ARD_D7) |         \
-                                     PIN_MODE_INPUT(GPIOA_ARD_D8) |         \
-                                     PIN_MODE_INPUT(GPIOA_ARD_D2) |         \
+                                     PIN_MODE_ALTERNATE(GPIOA_ARD_D8) |         \
+                                     PIN_MODE_ALTERNATE(GPIOA_ARD_D2) |         \
                                      PIN_MODE_ALTERNATE(GPIOA_OTG_FS_DM) |  \
                                      PIN_MODE_ALTERNATE(GPIOA_OTG_FS_DP) |  \
                                      PIN_MODE_OUTPUT(GPIOA_USER_LED) |      \
@@ -351,8 +351,8 @@
                                      PIN_OSPEED_HIGH(GPIOA_ARD_D12) |       \
                                      PIN_OSPEED_HIGH(GPIOA_ARD_D11) |       \
                                      PIN_OSPEED_HIGH(GPIOA_ARD_D7) |        \
-                                     PIN_OSPEED_HIGH(GPIOA_ARD_D8) |        \
-                                     PIN_OSPEED_HIGH(GPIOA_ARD_D2) |        \
+                                     PIN_OSPEED_MEDIUM(GPIOA_ARD_D8) |        \
+                                     PIN_OSPEED_MEDIUM(GPIOA_ARD_D2) |        \
                                      PIN_OSPEED_HIGH(GPIOA_OTG_FS_DM) |     \
                                      PIN_OSPEED_HIGH(GPIOA_OTG_FS_DP) |     \
                                      PIN_OSPEED_MEDIUM(GPIOA_USER_LED) |         \
@@ -367,8 +367,8 @@
                                      PIN_PUPDR_PULLUP(GPIOA_ARD_D12) |      \
                                      PIN_PUPDR_PULLUP(GPIOA_ARD_D11) |      \
                                      PIN_PUPDR_PULLUP(GPIOA_ARD_D7) |       \
-                                     PIN_PUPDR_PULLUP(GPIOA_ARD_D8) |       \
-                                     PIN_PUPDR_PULLUP(GPIOA_ARD_D2) |       \
+                                     PIN_PUPDR_FLOATING(GPIOA_ARD_D8) |       \
+                                     PIN_PUPDR_FLOATING(GPIOA_ARD_D2) |       \
                                      PIN_PUPDR_FLOATING(GPIOA_OTG_FS_DM) |  \
                                      PIN_PUPDR_FLOATING(GPIOA_OTG_FS_DP) |  \
                                      PIN_PUPDR_FLOATING(GPIOA_USER_LED) |        \
@@ -399,8 +399,8 @@
                                      PIN_AFIO_AF(GPIOA_ARD_D12, 0U) |       \
                                      PIN_AFIO_AF(GPIOA_ARD_D11, 0U))
 #define VAL_GPIOA_AFRH              (PIN_AFIO_AF(GPIOA_ARD_D7, 0U) |        \
-                                     PIN_AFIO_AF(GPIOA_ARD_D8, 0U) |        \
-                                     PIN_AFIO_AF(GPIOA_ARD_D2, 0U) |        \
+                                     PIN_AFIO_AF(GPIOA_ARD_D8, 7U) |        \
+                                     PIN_AFIO_AF(GPIOA_ARD_D2, 7U) |        \
                                      PIN_AFIO_AF(GPIOA_OTG_FS_DM, 10U) |    \
                                      PIN_AFIO_AF(GPIOA_OTG_FS_DP, 10U) |    \
                                      PIN_AFIO_AF(GPIOA_USER_LED, 0U) |         \

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoBooter/mcuconf.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoBooter/mcuconf.h
@@ -240,11 +240,11 @@
  * SERIAL driver system settings.
  */
 #define STM32_SERIAL_USE_USART1             FALSE
-#define STM32_SERIAL_USE_USART2             TRUE
+#define STM32_SERIAL_USE_USART2             FALSE
 #define STM32_SERIAL_USE_USART3             FALSE
 #define STM32_SERIAL_USE_UART4              FALSE
 #define STM32_SERIAL_USE_UART5              FALSE
-#define STM32_SERIAL_USE_USART6             FALSE
+#define STM32_SERIAL_USE_USART6             TRUE
 #define STM32_SERIAL_USART1_PRIORITY        12
 #define STM32_SERIAL_USART2_PRIORITY        12
 #define STM32_SERIAL_USART3_PRIORITY        12

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/halconf.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/halconf.h
@@ -31,9 +31,9 @@
 /**
  * @brief   Enables the ADC subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 // #if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
-// #define HAL_USE_ADC                 FALSE
+// #define HAL_USE_ADC                 TRUE
 // #endif
 
 /**
@@ -53,7 +53,7 @@
 /**
  * @brief   Enables the EXT subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 // #if !defined(HAL_USE_EXT) || defined(__DOXYGEN__)
 // #define HAL_USE_EXT                 FALSE
 // #endif
@@ -68,10 +68,11 @@
 /**
  * @brief   Enables the I2C subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 //#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
 //#define HAL_USE_I2C                 TRUE
 //#endif
+
 /**
  * @brief   Enables the I2S subsystem.
  */
@@ -89,7 +90,7 @@
 /**
  * @brief   Enables the MAC subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 // #if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
 // #define HAL_USE_MAC                 TRUE
 // #endif
@@ -104,15 +105,15 @@
 /**
  * @brief   Enables the PWM subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 // #if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
-// #define HAL_USE_PWM                 FALSE
+// #define HAL_USE_PWM                 TRUE
 // #endif
 
 /**
  * @brief   Enables the RTC subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 // #if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
 // #define HAL_USE_RTC                 TRUE
 // #endif
@@ -120,9 +121,10 @@
 /**
  * @brief   Enables the SDC subsystem.
  */
-#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
-#define HAL_USE_SDC                 FALSE
-#endif
+// this option is set at target_platform.h (from config file)
+// #if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+// #define HAL_USE_SDC                 FALSE
+// #endif
 
 /**
  * @brief   Enables the SERIAL subsystem.
@@ -141,17 +143,18 @@
 /**
  * @brief   Enables the SPI subsystem.
  */
-// this option is set at target_board.h (from config file)
+// this option is set at target_platform.h (from config file)
 // #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-// #define HAL_USE_SPI                 FALSE
+// #define HAL_USE_SPI                 TRUE
 // #endif
 
 /**
  * @brief   Enables the UART subsystem.
  */
-#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
-#define HAL_USE_UART                FALSE
-#endif
+// this option is set at target_platform.h (from config file)
+// #if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+// #define HAL_USE_UART                FALSE
+// #endif
 
 /**
  * @brief   Enables the USB subsystem.
@@ -350,7 +353,7 @@
  * @note    Disabling this option saves both code and data space.
  */
 #if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
-#define UART_USE_WAIT               FALSE
+#define UART_USE_WAIT               TRUE
 #endif
 
 /**
@@ -358,7 +361,7 @@
  * @note    Disabling this option saves both code and data space.
  */
 #if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
-#define UART_USE_MUTUAL_EXCLUSION   FALSE
+#define UART_USE_MUTUAL_EXCLUSION   TRUE
 #endif
 
 /*===========================================================================*/

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/mcuconf.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/mcuconf.h
@@ -281,7 +281,7 @@
 /*
  * UART driver system settings.
  */
-#define STM32_UART_USE_USART1               FALSE
+#define STM32_UART_USE_USART1               TRUE
 #define STM32_UART_USE_USART2               FALSE
 #define STM32_UART_USE_USART3               FALSE
 #define STM32_UART_USE_UART4                FALSE

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/mcuconf.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/mcuconf.h
@@ -240,11 +240,11 @@
  * SERIAL driver system settings.
  */
 #define STM32_SERIAL_USE_USART1             FALSE
-#define STM32_SERIAL_USE_USART2             TRUE
+#define STM32_SERIAL_USE_USART2             FALSE
 #define STM32_SERIAL_USE_USART3             FALSE
 #define STM32_SERIAL_USE_UART4              FALSE
 #define STM32_SERIAL_USE_UART5              FALSE
-#define STM32_SERIAL_USE_USART6             FALSE
+#define STM32_SERIAL_USE_USART6             TRUE
 #define STM32_SERIAL_USART1_PRIORITY        12
 #define STM32_SERIAL_USART2_PRIORITY        12
 #define STM32_SERIAL_USART3_PRIORITY        12
@@ -282,7 +282,7 @@
  * UART driver system settings.
  */
 #define STM32_UART_USE_USART1               TRUE
-#define STM32_UART_USE_USART2               FALSE
+#define STM32_UART_USE_USART2               TRUE
 #define STM32_UART_USE_USART3               FALSE
 #define STM32_UART_USE_UART4                FALSE
 #define STM32_UART_USE_UART5                FALSE

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
@@ -40,3 +40,39 @@ UART_INIT(1, UART1_TX_SIZE, UART1_RX_SIZE)
 // un-initialization for UART1
 UART_UNINIT(1)
 
+
+///////////
+// UART2 //
+///////////
+
+// pin configuration for UART2
+// port: GPIOA
+// TX pin: is GPIOA_2
+// RX pin: is GPIOA_3
+// GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
+UART_CONFIG_PINS(2, GPIOA, 2, 3, 7)
+
+// buffers size
+// tx buffer size: 1024 bytes
+#define UART2_TX_SIZE  1024
+// rx buffer size: 1024 bytes
+#define UART2_RX_SIZE  1024
+
+// buffers
+// buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
+// because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
+#if defined(__GNUC__)
+__attribute__((aligned (32)))
+#endif
+uint8_t Uart2_TxBuffer[UART2_TX_SIZE];
+#if defined(__GNUC__)
+__attribute__((aligned (32)))
+#endif
+uint8_t Uart2_RxBuffer[UART2_RX_SIZE];
+
+// initialization for UART2
+UART_INIT(2, UART2_TX_SIZE, UART2_RX_SIZE)
+
+// un-initialization for UART2
+UART_UNINIT(2)
+

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
@@ -14,7 +14,7 @@
 // TX pin: is GPIOA_9
 // RX pin: is GPIOA_10
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
-UART_CONFIG_PINS(1, GPIOA, 9, 10, 7)
+UART_CONFIG_PINS(1, GPIOA, GPIOA, 9, 10, 7)
 
 // buffers size
 // tx buffer size: 256 bytes
@@ -50,7 +50,7 @@ UART_UNINIT(1)
 // TX pin: is GPIOA_2
 // RX pin: is GPIOA_3
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
-UART_CONFIG_PINS(2, GPIOA, 2, 3, 7)
+UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
 
 // buffers size
 // tx buffer size: 1024 bytes

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+#include "win_dev_serial_native.h"
+
+///////////
+// UART1 //
+///////////
+
+// pin configuration for UART1
+// port: GPIOA
+// TX pin: is GPIOA_9
+// RX pin: is GPIOA_10
+// GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
+UART_CONFIG_PINS(1, GPIOA, 9, 10, 7)
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART1_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART1_RX_SIZE  256
+
+// buffers
+// buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
+// because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
+#if defined(__GNUC__)
+__attribute__((aligned (32)))
+#endif
+uint8_t Uart1_TxBuffer[UART1_TX_SIZE];
+#if defined(__GNUC__)
+__attribute__((aligned (32)))
+#endif
+uint8_t Uart1_RxBuffer[UART1_RX_SIZE];
+
+// initialization for UART1
+UART_INIT(1, UART1_TX_SIZE, UART1_RX_SIZE)
+
+// un-initialization for UART1
+UART_UNINIT(1)
+


### PR DESCRIPTION
- Activated USART6 in board header file
- Changed use of USART ports for serial
- Changed use of USARTS for the board

Now the two serial ports are mapped as must be. PA2, PA3 = USART2 and PA9, 10 for USART1.

Signed-off-by: piwi1263 <piwi1263@gmail.com>