### PR TITLE
Fix inclusion of target source file for serial API

### DIFF
--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
@@ -41,8 +41,21 @@ if(USE_NETWORKING_OPTION)
     find_package(CHIBIOS_LWIP REQUIRED)
 endif()
 
-#######################################
+# nF feature: filesystem
+if(USE_FILESYSTEM_OPTION)
+    find_package(CHIBIOS_FATFS REQUIRED)
+endif()
 
+####################################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
+
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -100,6 +113,9 @@ add_executable(
 
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
+
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
@@ -47,7 +47,15 @@ if(USE_FILESYSTEM_OPTION)
 endif()
 
 #######################################
+# sources for target specifc stuff related with APIs
+list(APPEND API_RELATED_TARGET_SOURCES "")
 
+# Windows.Devices.SerialCommunication
+if(API_Windows.Devices.SerialCommunication)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+#######################################
 
 add_subdirectory("common")
 add_subdirectory("nanoBooter")
@@ -105,9 +113,9 @@ add_executable(
 
     # sources for nanoFramework APIs
     "${TARGET_NANO_APIS_SOURCES}"
-        # sources for target specifc stuff related with APIs
-    # Windows.Devices.SerialCommunication
-    "target_windows_devices_serialcommunication_config.cpp"
+    
+    # sources for API which are target specific
+    "${API_RELATED_TARGET_SOURCES}"
 )
 
 # add dependency from ChibiOS (this is required to make sure the ChibiOS repo is downloaded before the build starts)


### PR DESCRIPTION
- The build was failing for targets that have the serial stuff setup and the CMake option is OFF

Signed-off-by: piwi1263 <piwi1263@gmail.com>

#I2M_OXYGEN_NF#
#I2M_ELECTRON_NF#

<!--- to request a build for a specific target include the target name inside '#' like this #I2M_OXYGEN_NF#, multiple targets can be build just add the respective token -->
<!--- to build all the targets use #ALL# -->
