### PR TITLE
Add support for ADC

### DIFF
--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 The nanoFramework project contributors
+# Copyright (c) 2018 The nanoFramework project contributors
 # See LICENSE file in the project root for full license information.
 #
 
@@ -46,13 +46,18 @@ if(USE_FILESYSTEM_OPTION)
     find_package(CHIBIOS_FATFS REQUIRED)
 endif()
 
-#######################################
+####################################################
 # sources for target specifc stuff related with APIs
 list(APPEND API_RELATED_TARGET_SOURCES "")
 
 # Windows.Devices.SerialCommunication
 if(API_Windows.Devices.SerialCommunication)
     list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_serialcommunication_config.cpp")    
+endif()
+
+# Windows.Devices.Adc
+if(API_Windows.Devices.Adc)
+    list(APPEND API_RELATED_TARGET_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/target_windows_devices_adc_config.cpp")    
 endif()
 
 #######################################

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/nanoCLR/mcuconf.h
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/nanoCLR/mcuconf.h
@@ -60,7 +60,7 @@
  * ADC driver system settings.
  */
 #define STM32_ADC_ADCPRE                    ADC_CCR_ADCPRE_DIV4
-#define STM32_ADC_USE_ADC1                  FALSE
+#define STM32_ADC_USE_ADC1                  TRUE
 #define STM32_ADC_USE_ADC2                  FALSE
 #define STM32_ADC_USE_ADC3                  FALSE
 #define STM32_ADC_ADC1_DMA_STREAM           STM32_DMA_STREAM_ID(2, 4)

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_windows_devices_adc_config.cpp
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_windows_devices_adc_config.cpp
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+ 
+#include "win_dev_adc_native.h"
+
+//////////
+// ADC1 //
+//////////
+
+const NF_PAL_ADC_PORT_PIN_CHANNEL Adc1PortPinConfig[] = {
+    {GPIOA, 4, ADC_CHANNEL_IN4},
+    {GPIOA, 5, ADC_CHANNEL_IN5},
+    {NULL, NULL, ADC_CHANNEL_SENSOR},
+    {NULL, NULL, ADC_CHANNEL_VREFINT},
+    {NULL, NULL, ADC_CHANNEL_VBAT},
+};
+
+const int Adc1ChannelCount = ARRAYSIZE(Adc1PortPinConfig);


### PR DESCRIPTION
Support for ADC has been added for PA4 and PA5.

Signed-off-by: piwi1263 <piwi1263@gmail.com>

<!--- to request a build for a specific target include the target name inside '#' like this #I2M_OXYGEN_NF#, multiple targets can be build just add the respective token -->
<!--- to build all the targets use #ALL# -->
