### PR TITLE
Add WireProtocol module sources to targets

### DIFF
--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/CMakeLists.txt
@@ -97,6 +97,8 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
+    ${WireProtocol_SOURCES}
+
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
@@ -97,6 +97,8 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
+    ${WireProtocol_SOURCES}
+
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
@@ -97,6 +97,8 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
+    ${WireProtocol_SOURCES}
+
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/CMakeLists.txt
@@ -97,6 +97,8 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
+    ${WireProtocol_SOURCES}
+
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/CMakeLists.txt
@@ -97,6 +97,8 @@ add_executable(
     ${CHIBIOS_SOURCES}
     ${ChibiOSnfOverlay_SOURCES}
 
+    ${WireProtocol_SOURCES}
+
     # sources for nanoFramework libraries
     "${NF_CoreCLR_SOURCES}"
     "${NF_Debugger_SOURCES}"


### PR DESCRIPTION
- Following nanoframework/nf-interpreter#764

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

#ALL#

