### PR TITLE
Work on targets to fix build

### DIFF
--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/CMakeLists.txt
@@ -61,6 +61,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOBOOTER_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/target_common.c
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/target_common.c
@@ -20,3 +20,5 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
     { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };
+
+HAL_TARGET_CONFIGURATION  g_TargetConfiguration;

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/CMakeLists.txt
@@ -61,6 +61,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOBOOTER_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_common.c
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_common.c
@@ -20,3 +20,5 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
     { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };
+
+HAL_TARGET_CONFIGURATION  g_TargetConfiguration;

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/CMakeLists.txt
@@ -61,6 +61,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOBOOTER_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_common.c
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_common.c
@@ -20,3 +20,5 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
     { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };
+
+HAL_TARGET_CONFIGURATION  g_TargetConfiguration;

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/CMakeLists.txt
@@ -62,6 +62,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOBOOTER_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/target_common.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/target_common.c
@@ -20,3 +20,5 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
     { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };
+
+HAL_TARGET_CONFIGURATION  g_TargetConfiguration;

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/CMakeLists.txt
@@ -61,6 +61,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOBOOTER_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/target_common.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/target_common.c
@@ -20,3 +20,5 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
     { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };
+
+HAL_TARGET_CONFIGURATION  g_TargetConfiguration;

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/CMakeLists.txt
@@ -61,6 +61,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOBOOTER_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/target_common.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/target_common.c
@@ -20,3 +20,5 @@ HAL_SYSTEM_CONFIG HalSystemConfig =
     { RAM1_MEMORY_StartAddress, RAM1_MEMORY_Size },
     { FLASH1_MEMORY_StartAddress, FLASH1_MEMORY_Size }
 };
+
+HAL_TARGET_CONFIGURATION  g_TargetConfiguration;


### PR DESCRIPTION
- Add g_TargetConfiguration global
- Add inclusion of nanoHAL_ConfigurationManager_stubs.c in booter
(all the above required after merge of network branch on develop)

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

#ALL#
