### PR TITLE
Align memory block when building MinSizRel

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/nanoCLR/STM32F401xE_CLR.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/nanoCLR/STM32F401xE_CLR.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 512k - 16k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash       : org = 0x08004000, len = 512k - 16k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
     config      : org = 0x00000000, len = 0                   /* space reserved for configuration block */
     deployment  : org = 0x08040000, len = 256k                /* space reserved for application deployment */
     ramvt       : org = 0x20000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */


### PR DESCRIPTION
The linker memory block was pointing to the wrong starting location.

- Fixes nanoframework/Home#418

Signed-off-by: piwi1263 <piwi1263@gmail.com>

#ST_NUCLEO64_F401RE_NF#
