### PR TITLE
Update GCC tools to 7-2018-q2-update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ configuration:
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
-  GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded\7-2017-q4-major'
+  GNU_GCC_TOOLCHAIN_PATH: 'C:\GNU_Tools_ARM_Embedded'
   NINJA_PATH: 'C:\mytools\ninja'
   HEX2DFU_PATH: 'C:\mytools\hex2dfu'
   RUBY_VERSION: 24

--- a/install-arm-gcc-toolchain.ps1
+++ b/install-arm-gcc-toolchain.ps1
@@ -9,7 +9,7 @@ If($GnuGccPathExists -eq $False)
 
     Write-Host "Downloading ARM GNU GCC toolchain..."
 
-    $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2017-q4-major-win32.7z"
+    $url = "https://bintray.com/nfbot/internal-build-tools/download_file?file_path=gcc-arm-none-eabi-7-2018-q2-update-win32.7z"
     $output = "$PSScriptRoot\gcc-arm.7z"
     
     # download 7zip with toolchain


### PR DESCRIPTION
## Description
- Remove version from path on appveyor (doesn't make much sense as it's temporary anyway and on update requires updating two different files)

## Motivation and Context
- Closes nanoFramework/Home#380

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

#ALL# 