### PR TITLE
Board fixes for Nucleo-F412ZG

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/CMakeLists.txt
@@ -89,6 +89,9 @@ add_executable(
     
     "${CMAKE_CURRENT_SOURCE_DIR}/target_common.c"
 
+    # need to add configuration manager to allow get/store configuration blocks
+    "${PROJECT_SOURCE_DIR}/src/HAL/nanoHAL_ConfigurationManager_stubs.c"
+
     ${COMMON_PROJECT_SOURCES}
     ${NANOCLR_PROJECT_SOURCES}
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/board.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/board.h
@@ -33,7 +33,7 @@
 /*
  * Board identifier.
  */
-#define BOARD_ST_NUCLEO144_F412ZG
+#define BOARD_ST_NUCLEO144_F412ZG_NF
 #define BOARD_NAME                  "STMicroelectronics STM32 Nucleo144-F412ZG"
 
 /*
@@ -687,8 +687,8 @@
                                      PIN_MODE_INPUT(GPIOB_ZIO_D22) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D26) |        \
                                      PIN_MODE_OUTPUT(GPIOB_LED2) |          \
-                                     PIN_MODE_INPUT(GPIOB_ARD_D15) |        \
-                                     PIN_MODE_INPUT(GPIOB_ARD_D14) |        \
+                                     PIN_MODE_ALTERNATE(GPIOB_ARD_D15) |        \
+                                     PIN_MODE_ALTERNATE(GPIOB_ARD_D14) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D36) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D35) |        \
                                      PIN_MODE_INPUT(GPIOB_ZIO_D19) |        \
@@ -703,8 +703,8 @@
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D22) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D26) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_LED2) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_ARD_D15) |    \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_ARD_D14) |    \
+                                     PIN_OTYPE_OPENDRAIN(GPIOB_ARD_D15) |    \
+                                     PIN_OTYPE_OPENDRAIN(GPIOB_ARD_D14) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D36) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D35) |    \
                                      PIN_OTYPE_PUSHPULL(GPIOB_ZIO_D19) |    \
@@ -735,8 +735,8 @@
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D22) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D26) |      \
                                      PIN_PUPDR_FLOATING(GPIOB_LED2) |       \
-                                     PIN_PUPDR_PULLUP(GPIOB_ARD_D15) |      \
-                                     PIN_PUPDR_PULLUP(GPIOB_ARD_D14) |      \
+                                     PIN_PUPDR_FLOATING(GPIOB_ARD_D15) |      \
+                                     PIN_PUPDR_FLOATING(GPIOB_ARD_D14) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D36) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D35) |      \
                                      PIN_PUPDR_PULLUP(GPIOB_ZIO_D19) |      \
@@ -751,8 +751,8 @@
                                      PIN_ODR_HIGH(GPIOB_ZIO_D22) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D26) |          \
                                      PIN_ODR_LOW(GPIOB_LED2) |              \
-                                     PIN_ODR_HIGH(GPIOB_ARD_D15) |          \
-                                     PIN_ODR_HIGH(GPIOB_ARD_D14) |          \
+                                     PIN_ODR_LOW(GPIOB_ARD_D15) |          \
+                                     PIN_ODR_LOW(GPIOB_ARD_D14) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D36) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D35) |          \
                                      PIN_ODR_HIGH(GPIOB_ZIO_D19) |          \
@@ -767,8 +767,8 @@
                                      PIN_AFIO_AF(GPIOB_ZIO_D22, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D26, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_LED2, 0U))
-#define VAL_GPIOB_AFRH              (PIN_AFIO_AF(GPIOB_ARD_D15, 0U) |       \
-                                     PIN_AFIO_AF(GPIOB_ARD_D14, 0U) |       \
+#define VAL_GPIOB_AFRH              (PIN_AFIO_AF(GPIOB_ARD_D15, 4U) |       \
+                                     PIN_AFIO_AF(GPIOB_ARD_D14, 4U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D36, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D35, 0U) |       \
                                      PIN_AFIO_AF(GPIOB_ZIO_D19, 0U) |       \

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/common/Device_BlockStorage-DEBUG.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/common/Device_BlockStorage-DEBUG.c
@@ -10,8 +10,7 @@
 const BlockRange BlockRange1[] = 
 {
     { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 0x08000000 nanoBooter          
-    { BlockRange_BLOCKTYPE_CONFIG    ,   1, 1 },            // 0x08008000 configuration block          
-    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 0x08010000 nanoCLR  
+    { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 0x08008000 nanoCLR  
 };
 
 //128kB block
@@ -23,8 +22,7 @@ const BlockRange BlockRange2[] =
 // 256kB blocks
 const BlockRange BlockRange3[] =
 {
-    { BlockRange_BLOCKTYPE_CODE,         0, 0 },            // 0x08040000 nanoCLR         
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   1, 2 }             // 0x08080000 deployment  
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   0, 2 }             // 0x08040000 deployment  
 };
 
 const BlockRegionInfo BlockRegions[] = 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/common/Device_BlockStorage.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/common/Device_BlockStorage.c
@@ -10,8 +10,7 @@
 const BlockRange BlockRange1[] = 
 {
     { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 0x08000000 nanoBooter          
-    { BlockRange_BLOCKTYPE_CONFIG    ,   1, 1 },            // 0x08008000 configuration block          
-    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 0x08010000 nanoCLR          
+    { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 0x08008000 nanoCLR          
 };
 
 //128kB block

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/common/usbcfg.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/common/usbcfg.c
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 The nanoFramework project contributors
+// Copyright (c) 2017..2018 The nanoFramework project contributors
 // Portions Copyright (c) 2006..2015 Giovanni Di Sirio.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
@@ -10,11 +10,11 @@
 SerialUSBDriver SDU1;
 
 /*
- * Endpoints to be used for USBD1.
+ * Endpoints to be used for USBD2.
  */
-#define USBD1_DATA_REQUEST_EP           1
-#define USBD1_DATA_AVAILABLE_EP         1
-#define USBD1_INTERRUPT_REQUEST_EP      2
+#define USBD2_DATA_REQUEST_EP           1
+#define USBD2_DATA_AVAILABLE_EP         1
+#define USBD2_INTERRUPT_REQUEST_EP      2
 
 // address for device unique ID
 // valid for STM32F4 series
@@ -76,7 +76,7 @@ typedef struct usb_string_serial_number
 /*
  * USB Device Descriptor.
  */
-static const uint8_t vcom_device_descriptor_data[18] = {
+static const uint8_t vcom_device_descriptor_data[] = {
   USB_DESC_DEVICE       (0x0200,        /* bcdUSB (2.0).                    */
                          0x02,          /* bDeviceClass (CDC).              */
                          0x00,          /* bDeviceSubClass.                 */
@@ -100,9 +100,9 @@ static const USBDescriptor vcom_device_descriptor = {
 };
 
 /* Configuration Descriptor tree for a CDC.*/
-static const uint8_t vcom_configuration_descriptor_data[67] = {
+static const uint8_t vcom_configuration_descriptor_data[] = {
   /* Configuration Descriptor.*/
-  USB_DESC_CONFIGURATION(67,            /* wTotalLength.                    */
+  USB_DESC_CONFIGURATION(0x0043,            /* wTotalLength.                    */
                          0x02,          /* bNumInterfaces.                  */
                          0x01,          /* bConfigurationValue.             */
                          0,             /* iConfiguration.                  */
@@ -149,7 +149,7 @@ static const uint8_t vcom_configuration_descriptor_data[67] = {
   USB_DESC_BYTE         (0x01),         /* bSlaveInterface0 (Data Class
                                            Interface).                      */
   /* Endpoint 2 Descriptor.*/
-  USB_DESC_ENDPOINT     (USBD1_INTERRUPT_REQUEST_EP|0x80,
+  USB_DESC_ENDPOINT     (USBD2_INTERRUPT_REQUEST_EP|0x80,
                          0x03,          /* bmAttributes (Interrupt).        */
                          0x0008,        /* wMaxPacketSize.                  */
                          0xFF),         /* bInterval.                       */
@@ -165,12 +165,12 @@ static const uint8_t vcom_configuration_descriptor_data[67] = {
                                            4.7).                            */
                          0x00),         /* iInterface.                      */
   /* Endpoint 3 Descriptor.*/
-  USB_DESC_ENDPOINT     (USBD1_DATA_AVAILABLE_EP,       /* bEndpointAddress.*/
+  USB_DESC_ENDPOINT     (USBD2_DATA_AVAILABLE_EP,       /* bEndpointAddress.*/
                          0x02,          /* bmAttributes (Bulk).             */
                          0x0040,        /* wMaxPacketSize.                  */
                          0x00),         /* bInterval.                       */
   /* Endpoint 1 Descriptor.*/
-  USB_DESC_ENDPOINT     (USBD1_DATA_REQUEST_EP|0x80,    /* bEndpointAddress.*/
+  USB_DESC_ENDPOINT     (USBD2_DATA_REQUEST_EP|0x80,    /* bEndpointAddress.*/
                          0x02,          /* bmAttributes (Bulk).             */
                          0x0040,        /* wMaxPacketSize.                  */
                          0x00)          /* bInterval.                       */
@@ -365,14 +365,19 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
   case USB_EVENT_CONFIGURED:
     chSysLockFromISR();
 
-    /* Enables the endpoints specified into the configuration.
-       Note, this callback is invoked from an ISR so I-Class functions
-       must be used.*/
-    usbInitEndpointI(usbp, USBD1_DATA_REQUEST_EP, &ep1config);
-    usbInitEndpointI(usbp, USBD1_INTERRUPT_REQUEST_EP, &ep2config);
+    if (usbp->state == USB_ACTIVE) {
+      /* Enables the endpoints specified into the configuration.
+         Note, this callback is invoked from an ISR so I-Class functions
+         must be used.*/
+      usbInitEndpointI(usbp, USBD2_DATA_REQUEST_EP, &ep1config);
+      usbInitEndpointI(usbp, USBD2_INTERRUPT_REQUEST_EP, &ep2config);
 
-    /* Resetting the state of the CDC subsystem.*/
-    sduConfigureHookI(&SDU1);
+      /* Resetting the state of the CDC subsystem.*/
+      sduConfigureHookI(&SDU1);
+    }
+    else if (usbp->state == USB_SELECTED) {
+      usbDisableEndpointsI(usbp);
+    }
 
     chSysUnlockFromISR();
     return;
@@ -403,6 +408,20 @@ static void usb_event(USBDriver *usbp, usbevent_t event) {
 }
 
 /*
+ * Handling messages not implemented in the default handler nor in the
+ * SerialUSB handler.
+ */
+static bool requests_hook(USBDriver *usbp) {
+
+  if (((usbp->setup[0] & USB_RTYPE_RECIPIENT_MASK) == USB_RTYPE_RECIPIENT_INTERFACE) &&
+      (usbp->setup[1] == USB_REQ_SET_INTERFACE)) {
+    usbSetupTransfer(usbp, NULL, 0, NULL);
+    return true;
+  }
+  return sduRequestsHook(usbp);
+}
+
+/*
  * Handles the USB driver global events.
  */
 static void sof_handler(USBDriver *usbp) {
@@ -420,7 +439,7 @@ static void sof_handler(USBDriver *usbp) {
 const USBConfig usbcfg = {
   usb_event,
   get_descriptor,
-  sduRequestsHook,
+  requests_hook,
   sof_handler
 };
 
@@ -429,7 +448,7 @@ const USBConfig usbcfg = {
  */
 const SerialUSBConfig serusbcfg = {
   &USBD1,
-  USBD1_DATA_REQUEST_EP,
-  USBD1_DATA_AVAILABLE_EP,
-  USBD1_INTERRUPT_REQUEST_EP
+  USBD2_DATA_REQUEST_EP,
+  USBD2_DATA_AVAILABLE_EP,
+  USBD2_INTERRUPT_REQUEST_EP
 };

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/STM32F412xG_booter-DEBUG.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/STM32F412xG_booter-DEBUG.ld
@@ -13,7 +13,7 @@
 MEMORY
 {
     flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08007FFF)*/
-    config      : org = 0x08008000, len = 32k     /* space reserved for configuration block */
+    config      : org = 0x00000000, len = 0       /* space reserved for configuration block */
     deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */
     ram0        : org = 0x20000000, len = 256k    /* SRAM1 */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/STM32F412xG_booter.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/STM32F412xG_booter.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08000000, len = 16k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08003FFF)*/
+    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st sector 0x08000000 to 0x08007FFF)*/
     config      : org = 0x00000000, len = 0       /* space reserved for configuration block */
     deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/chconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/chconf.h
@@ -125,7 +125,7 @@
  * @note    This is not related to the compiler optimization options.
  * @note    The default is @p TRUE.
  */
-#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#define CH_CFG_OPTIMIZE_SPEED               FALSE
 
 /** @} */
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/halconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/halconf.h
@@ -228,7 +228,6 @@
 #define CAN_USE_SLEEP_MODE                  TRUE
 #endif
 
-
 /**
  * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
  */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/main.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/main.c
@@ -29,12 +29,7 @@ int main(void) {
   SwoInit();
   #endif
 
-  // The kernel is initialized but not started yet, this means that
-  // main() is executing with absolute priority but interrupts are already enabled.
-  osKernelInitialize();
-  osDelay(20);    // Let init stabilize
-  
-   // the following IF is not mandatory, it's just providing a way for a user to 'force'
+  // the following IF is not mandatory, it's just providing a way for a user to 'force'
   // the board to remain in nanoBooter and not launching nanoCLR
 
   // if the USER button (blue one) is pressed, skip the check for a valid CLR image and remain in booter
@@ -43,13 +38,17 @@ int main(void) {
   {
     // check for valid CLR image 
     // we are checking for a valid image right after the configuration block
-    if(CheckValidCLRImage((uint32_t)&__nanoConfig_end__))
+    if(CheckValidCLRImage((uint32_t)&__nanoImage_end__))
     {
       // there seems to be a valid CLR image
       // launch nanoCLR
-      LaunchCLR((uint32_t)&__nanoConfig_end__);
+      LaunchCLR((uint32_t)&__nanoImage_end__);
     }
   }
+
+  // The kernel is initialized but not started yet, this means that
+  // main() is executing with absolute priority but interrupts are already enabled.
+  osKernelInitialize();
 
   //  Initializes a serial-over-USB CDC driver.
   sduObjectInit(&SDU1);

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/mcuconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/mcuconf.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2017 The nanoFramework project contributors
-// Portions Copyright (c) 2006..2015 Giovanni Di Sirio. All rights reserved.
+// Portions Copyright (c) 2006..2015 Giovanni Di Sirio.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
 
@@ -26,11 +26,7 @@
 /*
  * HAL driver system settings.
  */
-
 #define STM32_NO_INIT                       FALSE
-#define STM32_PVD_ENABLE                    FALSE
-#define STM32_PLS                           STM32_PLS_LEV0
-#define STM32_BKPRAM_ENABLE                 FALSE
 #define STM32_HSI_ENABLED                   TRUE
 #define STM32_LSI_ENABLED                   TRUE
 #define STM32_HSE_ENABLED                   TRUE
@@ -54,6 +50,27 @@
 #define STM32_I2SSRC                        STM32_I2SSRC_CKIN
 #define STM32_PLLI2SN_VALUE                 192
 #define STM32_PLLI2SR_VALUE                 5
+#define STM32_PVD_ENABLE                    FALSE
+#define STM32_PLS                           STM32_PLS_LEV0
+#define STM32_BKPRAM_ENABLE                 FALSE
+
+/*
+ * IRQ system settings.
+ */
+#define STM32_IRQ_EXTI0_PRIORITY            6
+#define STM32_IRQ_EXTI1_PRIORITY            6
+#define STM32_IRQ_EXTI2_PRIORITY            6
+#define STM32_IRQ_EXTI3_PRIORITY            6
+#define STM32_IRQ_EXTI4_PRIORITY            6
+#define STM32_IRQ_EXTI5_9_PRIORITY          6
+#define STM32_IRQ_EXTI10_15_PRIORITY        6
+#define STM32_IRQ_EXTI16_PRIORITY           6
+#define STM32_IRQ_EXTI17_PRIORITY           15
+#define STM32_IRQ_EXTI18_PRIORITY           6
+#define STM32_IRQ_EXTI19_PRIORITY           6
+#define STM32_IRQ_EXTI20_PRIORITY           6
+#define STM32_IRQ_EXTI21_PRIORITY           15
+#define STM32_IRQ_EXTI22_PRIORITY           15
 
 /*
  * ADC driver system settings.
@@ -93,24 +110,6 @@
 #define STM32_DAC_DAC1_CH2_DMA_PRIORITY     2
 #define STM32_DAC_DAC1_CH1_DMA_STREAM       STM32_DMA_STREAM_ID(1, 5)
 #define STM32_DAC_DAC1_CH2_DMA_STREAM       STM32_DMA_STREAM_ID(1, 6)
-
-/*
- * EXT driver system settings.
- */
-#define STM32_EXT_EXTI0_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI1_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI2_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI3_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI4_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI5_9_IRQ_PRIORITY      6
-#define STM32_EXT_EXTI10_15_IRQ_PRIORITY    6
-#define STM32_EXT_EXTI16_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI17_IRQ_PRIORITY       15
-#define STM32_EXT_EXTI18_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI19_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI20_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI21_IRQ_PRIORITY       15
-#define STM32_EXT_EXTI22_IRQ_PRIORITY       15
 
 /*
  * GPT driver system settings.

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/STM32F412xG_CLR-DEBUG.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/STM32F412xG_CLR-DEBUG.ld
@@ -12,11 +12,11 @@
  */
 MEMORY
 {
-    flash       : org = 0x08010000, len = 1M - 32k -32k - 512k  /* flash size less the space reserved for nanoBooter and application deployment*/
-    config      : org = 0x08008000, len = 32k                   /* space reserved for configuration block */
-    deployment  : org = 0x08080000, len = 512k                  /* space reserved for application deployment */
-    ramvt       : org = 0x00000000, len = 0                     /* initial RAM address is reserved for a copy of the vector table */
-    ram0        : org = 0x20000000, len = 256k                  /* SRAM1 */
+    flash       : org = 0x08008000, len = 1M - 32k - 768k     /* flash size less the space reserved for nanoBooter and application deployment*/
+    config      : org = 0x00000000, len = 0                   /* space reserved for configuration block */
+    deployment  : org = 0x08040000, len = 768k                /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 256k                /* SRAM1 */
     ram1        : org = 0x00000000, len = 0                
     ram2        : org = 0x00000000, len = 0                
     ram3        : org = 0x00000000, len = 0

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/STM32F412xG_CLR.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/STM32F412xG_CLR.ld
@@ -12,11 +12,11 @@
  */
 MEMORY
 {
-    flash       : org = 0x08004000, len = 512k - 16k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash       : org = 0x08008000, len = 1M - 32k - 768k     /* flash size less the space reserved for nanoBooter and application deployment*/
     config      : org = 0x00000000, len = 0                   /* space reserved for configuration block */
-    deployment  : org = 0x08040000, len = 256k                /* space reserved for application deployment */
-    ramvt       : org = 0x20000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */
-    ram0        : org = 0x20000000, len = 128k                /* SRAM1 */
+    deployment  : org = 0x08040000, len = 768k                /* space reserved for application deployment */
+    ramvt       : org = 0x00000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */
+    ram0        : org = 0x20000000, len = 256k                /* SRAM1 */
     ram1        : org = 0x00000000, len = 0                
     ram2        : org = 0x00000000, len = 0                
     ram3        : org = 0x00000000, len = 0

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/mcuconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/mcuconf.h
@@ -56,6 +56,24 @@
  #define STM32_BKPRAM_ENABLE                 FALSE
 
 /*
+ * IRQ system settings.
+ */
+#define STM32_IRQ_EXTI0_PRIORITY            6
+#define STM32_IRQ_EXTI1_PRIORITY            6
+#define STM32_IRQ_EXTI2_PRIORITY            6
+#define STM32_IRQ_EXTI3_PRIORITY            6
+#define STM32_IRQ_EXTI4_PRIORITY            6
+#define STM32_IRQ_EXTI5_9_PRIORITY          6
+#define STM32_IRQ_EXTI10_15_PRIORITY        6
+#define STM32_IRQ_EXTI16_PRIORITY           6
+#define STM32_IRQ_EXTI17_PRIORITY           15
+#define STM32_IRQ_EXTI18_PRIORITY           6
+#define STM32_IRQ_EXTI19_PRIORITY           6
+#define STM32_IRQ_EXTI20_PRIORITY           6
+#define STM32_IRQ_EXTI21_PRIORITY           15
+#define STM32_IRQ_EXTI22_PRIORITY           15
+
+/*
  * ADC driver system settings.
  */
 #define STM32_ADC_ADCPRE                    ADC_CCR_ADCPRE_DIV4
@@ -93,24 +111,6 @@
 #define STM32_DAC_DAC1_CH2_DMA_PRIORITY     2
 #define STM32_DAC_DAC1_CH1_DMA_STREAM       STM32_DMA_STREAM_ID(1, 5)
 #define STM32_DAC_DAC1_CH2_DMA_STREAM       STM32_DMA_STREAM_ID(1, 6)
-
-/*
- * EXT driver system settings.
- */
-#define STM32_EXT_EXTI0_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI1_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI2_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI3_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI4_IRQ_PRIORITY        6
-#define STM32_EXT_EXTI5_9_IRQ_PRIORITY      6
-#define STM32_EXT_EXTI10_15_IRQ_PRIORITY    6
-#define STM32_EXT_EXTI16_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI17_IRQ_PRIORITY       15
-#define STM32_EXT_EXTI18_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI19_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI20_IRQ_PRIORITY       6
-#define STM32_EXT_EXTI21_IRQ_PRIORITY       15
-#define STM32_EXT_EXTI22_IRQ_PRIORITY       15
 
 /*
  * GPT driver system settings.


### PR DESCRIPTION
- Fixes memory block alignment.
- Fixes USB instabilities
- Correct I2C for Arduino pins

Signed-off-by: piwi1263 <piwi1263@gmail.com>

#ST_NUCLEO144_F412ZG_NF#
