### PR TITLE
Rework inclusion of UART declarations in STM32 targets

### DIFF
--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -15,12 +16,6 @@
 // RX pin: is GPIOB_7
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F405xx/STM32F407xx datasheet)
 UART_CONFIG_PINS(1, GPIOB, GPIOB, 6, 7, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART1_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART1_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -50,12 +45,6 @@ UART_UNINIT(1)
 // RX pin: is GPIOA_3
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F405xx/STM32F407xx datasheet)
 UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
-
-// buffers size
-// tx buffer size: 1024 bytes
-#define UART2_TX_SIZE  1024
-// rx buffer size: 1024 bytes
-#define UART2_RX_SIZE  1024
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/target_windows_devices_serialcommunication_config.h
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+///////////
+// UART1 //
+///////////
+
+// enable USART1
+#define NF_SERIAL_COMM_STM32_UART_USE_USART1    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART1_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART1_RX_SIZE  256
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 1024 bytes
+#define UART2_TX_SIZE  1024
+// rx buffer size: 1024 bytes
+#define UART2_RX_SIZE  1024

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -15,12 +16,6 @@
 // RX pin: is GPIOA_3
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
 UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
-
-// buffers size
-// tx buffer size: 1024 bytes
-#define UART2_TX_SIZE  1024
-// rx buffer size: 1024 bytes
-#define UART2_RX_SIZE  1024
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -39,4 +34,3 @@ UART_INIT(2, UART2_TX_SIZE, UART2_RX_SIZE)
 
 // un-initialization for UART2
 UART_UNINIT(2)
-

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_windows_devices_serialcommunication_config.h
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 1024 bytes
+#define UART2_TX_SIZE  1024
+// rx buffer size: 1024 bytes
+#define UART2_RX_SIZE  1024

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -15,12 +16,6 @@
 // RX pin: is GPIOA_10
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
 UART_CONFIG_PINS(1, GPIOA, GPIOA, 9, 10, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART1_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART1_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -52,12 +47,6 @@ UART_UNINIT(1)
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
 UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
 
-// buffers size
-// tx buffer size: 1024 bytes
-#define UART2_TX_SIZE  1024
-// rx buffer size: 1024 bytes
-#define UART2_RX_SIZE  1024
-
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
 // because of issues with cache coherency and DMA (this is particularly important with Cortex-M7 because of cache)
@@ -75,4 +64,3 @@ UART_INIT(2, UART2_TX_SIZE, UART2_RX_SIZE)
 
 // un-initialization for UART2
 UART_UNINIT(2)
-

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.h
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+///////////
+// UART1 //
+///////////
+
+// enable USART1
+#define NF_SERIAL_COMM_STM32_UART_USE_USART1    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART1_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART1_RX_SIZE  256
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 1024 bytes
+#define UART2_TX_SIZE  1024
+// rx buffer size: 1024 bytes
+#define UART2_RX_SIZE  1024

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -16,12 +17,6 @@
 // RX pin: is GPIOD_6
 // GPIO alternate pin function is 7 (see "Table 10. STM32F412xE/G alternate function mapping" in datasheet)
 UART_CONFIG_PINS(2, GPIOD, GPIOD, 5, 6, 7)
-
-// buffers size
-// tx buffer size: 256 bytes
-#define UART2_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART2_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/target_windows_devices_serialcommunication_config.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size
+// tx buffer size: 256 bytes
+#define UART2_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART2_RX_SIZE  256

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -15,12 +16,6 @@
 // RX pin: is GPIOA_3
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F401xC and STM32F401xE datasheet)
 UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
-
-// buffers size 
-// tx buffer size: 256 bytes
-#define UART2_TX_SIZE  256
-// rx buffer size: 256 bytes
-#define UART2_RX_SIZE  256
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -39,4 +34,3 @@ UART_INIT(2, UART2_TX_SIZE, UART2_RX_SIZE)
 
 // un-initialization for UART2
 UART_UNINIT(2)
-

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/target_windows_devices_serialcommunication_config.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size 
+// tx buffer size: 256 bytes
+#define UART2_TX_SIZE  256
+// rx buffer size: 256 bytes
+#define UART2_RX_SIZE  256

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/target_windows_devices_serialcommunication_config.cpp
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/target_windows_devices_serialcommunication_config.cpp
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#include "target_windows_devices_serialcommunication_config.h"
 #include "win_dev_serial_native.h"
 
 ///////////
@@ -15,12 +16,6 @@
 // RX pin: is GPIOA_3
 // GPIO alternate pin function is 7 (see "Table 9. Alternate function mapping" in STM32F411xC and STM32F411xE datasheet)
 UART_CONFIG_PINS(2, GPIOA, GPIOA, 2, 3, 7)
-
-// buffers size 
-// tx buffer size: 1024 bytes
-#define UART2_TX_SIZE  1024
-// rx buffer size: 1024 bytes
-#define UART2_RX_SIZE  1024
 
 // buffers
 // buffers that are R/W by DMA are recommended to be aligned with 32 bytes cache page size boundary
@@ -39,4 +34,3 @@ UART_INIT(2, UART2_TX_SIZE, UART2_RX_SIZE)
 
 // un-initialization for UART2
 UART_UNINIT(2)
-

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/target_windows_devices_serialcommunication_config.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/target_windows_devices_serialcommunication_config.h
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+
+///////////
+// UART2 //
+///////////
+
+// enable USART2
+#define NF_SERIAL_COMM_STM32_UART_USE_USART2    TRUE
+
+// buffers size 
+// tx buffer size: 1024 bytes
+#define UART2_TX_SIZE  1024
+// rx buffer size: 1024 bytes
+#define UART2_RX_SIZE  1024


### PR DESCRIPTION
- Following nanoFramework/nf-interpreter#951

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
