### PR TITLE
Fix 1-Wire configs

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/halconf_nf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/halconf_nf.h
@@ -16,9 +16,4 @@
 #define HAL_USE_STM32_FLASH         TRUE
 #endif
 
-// enables STM32 One Wire driver
-#if !defined(HAL_USE_STM32_ONEWIRE) 
-#define HAL_USE_STM32_ONEWIRE       TRUE
-#endif
-
 #endif // _HALCONF_NF_H_

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_nf_devices_onewire_config.cpp
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_nf_devices_onewire_config.cpp
@@ -4,7 +4,7 @@
 //
 
 #include "target_nf_devices_onewire_config.h"
-#include <hal.h>
+#include <nf_devices_onewire_native.h>
 
 ///////////
 // UART4 //

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_nf_devices_onewire_config.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_nf_devices_onewire_config.h
@@ -3,14 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-// the following macro defines a function that configures the GPIO pins for a STM32 UART/USART
-// it gets called in the oneWire_lld_start function
-// this is required because the UART/USART peripherals can use multiple GPIO configuration combinations
-#define UART_CONFIG_PINS(num, gpio_port_tx, tx_pin, alternate_function) void ConfigPins_UART##num() { \
-    palSetPadMode(gpio_port_tx, tx_pin, PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OTYPE_OPENDRAIN \
-    | PAL_MODE_INPUT_PULLUP | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_MODE_ALTERNATE); \
-}
-
 ///////////
 // UART4 //
 ///////////

--- a/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/halconf_nf.h
+++ b/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/halconf_nf.h
@@ -16,11 +16,6 @@
 #define HAL_USE_STM32_FLASH         TRUE
 #endif
 
-// enables STM32 One Wire driver
-#if !defined(HAL_USE_STM32_ONEWIRE) 
-#define HAL_USE_STM32_ONEWIRE       TRUE
-#endif
-
 // enables STM32 Can driver
 #if !defined(HAL_USE_STM32_CAN) 
 #define HAL_USE_STM32_CAN       TRUE

--- a/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_nf_devices_onewire_config.cpp
+++ b/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_nf_devices_onewire_config.cpp
@@ -4,7 +4,7 @@
 //
 
 #include "target_nf_devices_onewire_config.h"
-#include <hal.h>
+#include <nf_devices_onewire_native.h>
 
 ///////////
 // UART4 //

--- a/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_nf_devices_onewire_config.h
+++ b/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/target_nf_devices_onewire_config.h
@@ -3,13 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-// the following macro defines a function that configures the GPIO pins for a STM32 UART/USART
-// it gets called in the oneWire_lld_start function// this is required because the UART/USART peripherals can use multiple GPIO configuration combinations
-#define UART_CONFIG_PINS(num, gpio_port_tx, tx_pin, alternate_function) void ConfigPins_UART##num() { \
-    palSetPadMode(gpio_port_tx, tx_pin, PAL_MODE_ALTERNATE(alternate_function) | PAL_STM32_OTYPE_OPENDRAIN \
-    | PAL_MODE_INPUT_PULLUP | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_MODE_ALTERNATE); \
-}
-
 ///////////
 // UART4 //
 ///////////


### PR DESCRIPTION
- Following nanoframework/nf-interpreter#1145.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

#ST_NUCLEO144_F746ZG#
#ST_STM32F4_DISCOVERY#
