### PR TITLE
Improvements in STM32F746ZG target

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/CMakeLists.txt
@@ -231,7 +231,7 @@ nf_set_linker_options(${NANOCLR_PROJECT_NAME}.elf)
 ###########################################################
 # the sizes of CRT heap and ChibiOS stacks are defined here
 set_property(TARGET ${NANOBOOTER_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x400,--defsym=__crt_heap_size__=0x1000")
-set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0xCF00")
+set_property(TARGET ${NANOCLR_PROJECT_NAME}.elf APPEND_STRING PROPERTY LINK_FLAGS ",--defsym=__main_stack_size__=0x400,--defsym=__process_stack_size__=0x800,--defsym=__crt_heap_size__=0x10000")
 
 # generate output files
 nf_generate_build_output_files(${NANOBOOTER_PROJECT_NAME}.elf)

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/lwipopts.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/lwipopts.h
@@ -137,7 +137,7 @@
  * a lot of data that needs to be copied, this should be set high.
  */
 #ifndef MEM_SIZE
-#define MEM_SIZE                        (10 * 1024)
+#define MEM_SIZE                        (16 * 1024)
 #endif
 
 /**
@@ -266,7 +266,7 @@
  * (requires the LWIP_TCP option)
  */
 #ifndef MEMP_NUM_TCP_PCB
-#define MEMP_NUM_TCP_PCB                4
+#define MEMP_NUM_TCP_PCB                5
 #endif
 
 /**
@@ -274,7 +274,7 @@
  * (requires the LWIP_TCP option)
  */
 #ifndef MEMP_NUM_TCP_PCB_LISTEN
-#define MEMP_NUM_TCP_PCB_LISTEN         4
+#define MEMP_NUM_TCP_PCB_LISTEN         8
 #endif
 
 /**
@@ -282,7 +282,7 @@
  * (requires the LWIP_TCP option)
  */
 #ifndef MEMP_NUM_TCP_SEG
-#define MEMP_NUM_TCP_SEG                8
+#define MEMP_NUM_TCP_SEG                16
 #endif
 
 /**

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_common.h.in
@@ -33,11 +33,4 @@
 #define PLATFORM_HAS_RNG       TRUE
 /////////////////////////////////////
 
-//////////////////////////////////////////////
-// set Wire Protocol packet size
-// valid sizes are 1024, 512, 256, 128
-// check Monitor_Ping_Source_Flags enum
-#define WP_PACKET_SIZE                  512U
-//////////////////////////////////////////////
-
 #endif /* _TARGET_COMMON_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_lwip_sntp_opts.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/target_lwip_sntp_opts.h
@@ -11,8 +11,8 @@
 
 // better have a startup delay because we can have DHCP enabled (default 30 seconds)
 // value in milliseconds
-#define SNTP_STARTUP_DELAY      30000
+#define SNTP_STARTUP_DELAY      5000
 
-// retry timeout (15 minutes)
+// retry timeout (2 minutes)
 // value in milliseconds
-#define SNTP_RETRY_TIMEOUT      900000
+#define SNTP_RETRY_TIMEOUT      2*6000


### PR DESCRIPTION
- Update lwIP configs.
- Remove short WP package config.
- Increase CRT heap size.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

#ST_NUCLEO144_F746ZG#
