### PR TITLE
Update build tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 <!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
 - Fixes/Closes/Resolves nanoFramework/Home#NNNN
-<!--- to request a build for a specific target include the target name inside '#' like this #I2M_OXYGEN_NF#, multiple targets can be build just add the respective token -->
-<!--- to build all the targets use #ALL# -->
+<!--- to request a build for a specific target include the target name inside '***' like this ***I2M_OXYGEN_NF***, multiple targets can be build just add the respective token -->
+<!--- to build all the targets use ***ALL*** -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
 
 ##############################
 - job: Build_GHI_FEZ_CERB40_NF
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#GHI_FEZ_CERB40_NF#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***GHI_FEZ_CERB40_NF***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -118,7 +118,7 @@ jobs:
 
 ##############################
 - job: Build_I2M_ELECTRON_NF
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#I2M_ELECTRON_NF#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***I2M_ELECTRON_NF***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -157,7 +157,7 @@ jobs:
 
 ##############################
 - job: Build_I2M_OXYGEN_NF
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#I2M_OXYGEN_NF#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***I2M_OXYGEN_NF***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -196,7 +196,7 @@ jobs:
 
 ##############################
 - job: Build_ST_NUCLEO64_F401RE_NF
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ST_NUCLEO64_F401RE_NF#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ST_NUCLEO64_F401RE_NF***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -235,7 +235,7 @@ jobs:
 
 ##############################
 - job: Build_ST_NUCLEO64_F411RE_NF
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ST_NUCLEO64_F411RE_NF#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ST_NUCLEO64_F411RE_NF***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -274,7 +274,7 @@ jobs:
 
 ##############################
 - job: Build_ST_NUCLEO144_F412ZG_NF
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ST_NUCLEO144_F412ZG_NF#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ST_NUCLEO144_F412ZG_NF***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -313,7 +313,7 @@ jobs:
 
 ##############################
 - job: Build_ST_NUCLEO144_F746ZG
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ST_NUCLEO144_F746ZG#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ST_NUCLEO144_F746ZG***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -352,7 +352,7 @@ jobs:
 
 ##############################
 - job: Build_ST_STM32F4_DISCOVERY
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ST_STM32F4_DISCOVERY#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ST_STM32F4_DISCOVERY***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'
@@ -391,7 +391,7 @@ jobs:
 
 ##############################
 - job: Build_ST_NUCLEO144_F439ZI
-  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ST_NUCLEO144_F439ZI#'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '#ALL#'), eq(variables['BUILD_ALL'], 'true') )
+  condition: or( contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ST_NUCLEO144_F439ZI***'), contains(dependencies.Get_Commit_Message.outputs['getCommitMessage.COMMIT_MESSAGE'], '***ALL***'), eq(variables['BUILD_ALL'], 'true') )
   dependsOn: Get_Commit_Message
   pool:
     vmImage: 'VS2017-Win2016'


### PR DESCRIPTION
- Replace # with *** because the pound char is used in github messages to tag something and has other uses in Azure Pipelines. The triple asterisk seems to be a rather common pattern for this purpose.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
