### PR TITLE
Work on ST_NUCLEO64_F411RE

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/board.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/board.h
@@ -33,11 +33,6 @@
 #define BOARD_NAME                  "STMicroelectronics STM32 Nucleo64-F411RE for nanoFramework"
 
 /*
- * USB OTG Force
- */
-#define BOARD_OTG_NOVBUSSENS
-
-/*
  * Completely wacko definition of a flash sector here
  */
 #define FLASH_SECTOR_11    ((uint32_t)11U)
@@ -54,7 +49,7 @@
 #define STM32_HSECLK                8000000U
 #endif
 
-//#define STM32_HSE_BYPASS
+#define STM32_HSE_BYPASS
 
 /*
  * Board voltages.
@@ -277,7 +272,6 @@
 #define LINE_BUTTON                 PAL_LINE(GPIOC, 13U)
 #define LINE_OSC32_IN               PAL_LINE(GPIOC, 14U)
 #define LINE_OSC32_OUT              PAL_LINE(GPIOC, 15U)
-
 
 
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/common/Device_BlockStorage-DEBUG.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/common/Device_BlockStorage-DEBUG.c
@@ -9,21 +9,21 @@
 //16kB block
 const BlockRange BlockRange1[] = 
 {
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 1 },            // 08000000 nanoBooter          
-    { BlockRange_BLOCKTYPE_CODE      ,   2, 3 }             // 08008000 nanoCLR          
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 08000000 nanoBooter
+    { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 08004000 nanoCLR
 };
 
 //64kB block
 const BlockRange BlockRange2[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR          
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR
 };
 
 //384kB block
 const BlockRange BlockRange3[] =
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 1 },            // 08020000 nanoCLR         
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   2, 5 }             // 08040000 deployment  
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 },            // 08020000 nanoCLR         
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   1, 2 }             // 08040000 deployment  
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -49,8 +49,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         0x08020000,                         // start address for block region
-        6,                                  // total number of blocks in this region
-        0x10000,                            // total number of bytes per block
+        3,                                  // total number of blocks in this region
+        0x20000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3,
     },

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/common/Device_BlockStorage.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/common/Device_BlockStorage.c
@@ -9,21 +9,21 @@
 //16kB block
 const BlockRange BlockRange1[] = 
 {
-    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 08000000 nanoBooter          
-    { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 08004000 nanoCLR          
+    { BlockRange_BLOCKTYPE_BOOTSTRAP ,   0, 0 },            // 08000000 nanoBooter
+    { BlockRange_BLOCKTYPE_CODE      ,   1, 3 }             // 08004000 nanoCLR
 };
 
 //64kB block
 const BlockRange BlockRange2[] = 
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR          
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 }             // 08010000 nanoCLR
 };
 
 //384kB block
 const BlockRange BlockRange3[] =
 {
-    { BlockRange_BLOCKTYPE_CODE      ,   0, 1 },            // 08020000 nanoCLR         
-    { BlockRange_BLOCKTYPE_DEPLOYMENT,   2, 5 }             // 08040000 deployment  
+    { BlockRange_BLOCKTYPE_CODE      ,   0, 0 },            // 08020000 nanoCLR
+    { BlockRange_BLOCKTYPE_DEPLOYMENT,   1, 2 }             // 08040000 deployment
 };
 
 const BlockRegionInfo BlockRegions[] = 
@@ -49,8 +49,8 @@ const BlockRegionInfo BlockRegions[] =
     {
         (0),                                // no attributes for this region
         0x08020000,                         // start address for block region
-        6,                                  // total number of blocks in this region
-        0x10000,                            // total number of bytes per block
+        3,                                  // total number of blocks in this region
+        0x20000,                            // total number of bytes per block
         ARRAYSIZE_CONST_EXPR(BlockRange3),
         BlockRange3,
     },

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/STM32F411xE_booter-DEBUG.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/STM32F411xE_booter-DEBUG.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08000000, len = 32k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
+    flash       : org = 0x08000000, len = 16k     /* space reserved for nanoBooter (1st two sectors 0x08000000 to 0x08008000)*/
     config      : org = 0x00000000, len = 0       /* space reserved for configuration block */
     deployment  : org = 0x00000000, len = 0       /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0       /* initial RAM address is reserved for a copy of the vector table */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/chconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/chconf.h
@@ -39,7 +39,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 1000 // this is 1 millisecond
+#define CH_CFG_ST_FREQUENCY                 10000 // this is 1 millisecond
 
 /**
  * @brief   Time intervals data size.

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoCLR/STM32F411xE_CLR-DEBUG.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoCLR/STM32F411xE_CLR-DEBUG.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08008000, len = 512k - 32k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash       : org = 0x08004000, len = 512k - 16k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
     config      : org = 0x00000000, len = 0                   /* space reserved for configuration block */
     deployment  : org = 0x08040000, len = 256k                /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */


### PR DESCRIPTION
- Fix block storage definition.
- Adjust booter block definition.
- Update linker files accordingly.
- Add STM32_HSE_BYPASS (required because CLK is comming from ST-Link MCU and it's required for USB clocking).
- Remove BOARD_OTG_NOVBUSSENS.

***ST_NUCLEO64_F411RE_NF***