### PR TITLE
ST_NUCLEO64_F411RE_NF: Correcting comment on CH_CFG_ST_FREQUENCY

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/chconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/chconf.h
@@ -39,7 +39,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 10000 // this is 10 millisecond
+#define CH_CFG_ST_FREQUENCY                 10000 // these are are 100 microseconds
 
 /**
  * @brief   Time intervals data size.

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/chconf.h
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoBooter/chconf.h
@@ -39,7 +39,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 10000 // this is 1 millisecond
+#define CH_CFG_ST_FREQUENCY                 10000 // this is 10 millisecond
 
 /**
  * @brief   Time intervals data size.


### PR DESCRIPTION
As far as I understand the value is given in microseconds, therefore it must be 10milliseconds, no?