### PR TITLE
Correcting STM32F411xE_CLR-DEBUG.ld  flash size

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoCLR/STM32F411xE_CLR-DEBUG.ld
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoCLR/STM32F411xE_CLR-DEBUG.ld
@@ -12,7 +12,7 @@
  */
 MEMORY
 {
-    flash       : org = 0x08004000, len = 512k - 32k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
+    flash       : org = 0x08008000, len = 512k - 32k - 256k   /* flash size less the space reserved for nanoBooter and application deployment*/
     config      : org = 0x00000000, len = 0                   /* space reserved for configuration block */
     deployment  : org = 0x08040000, len = 256k                /* space reserved for application deployment */
     ramvt       : org = 0x00000000, len = 0                   /* initial RAM address is reserved for a copy of the vector table */


### PR DESCRIPTION
Correcting STM32F411xE_CLR-DEBUG.ld  flash address from  0x08004000 to 0x08008000