### PR TITLE
ST_NUCLEO64_F411RE_NF: main: Remove ASAP²

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoCLR/main.c
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/nanoCLR/main.c
@@ -30,10 +30,10 @@ int main(void) {
   // and performs the board-specific initializations.
   halInit();
 
-  // init SWO as soon as possible to make it available to output ASAP
-  #if (SWO_OUTPUT == TRUE)  
+  // Init SWO to make it available to output as soon as possible
+#if (SWO_OUTPUT == TRUE)  
   SwoInit();
-  #endif
+#endif
   
   // The kernel is initialized but not started yet, this means that
   // main() is executing with absolute priority but interrupts are already enabled.


### PR DESCRIPTION
Also moved the compiler's preprocessors if-clause one level down.
I know from kernel development that people tend to have it there always.
Love it or hate it.

Oh, yes, just edited the comment a bit.