### PR TITLE
Rework OEM string for community boards

### DIFF
--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/GHI_FEZ_CERB40_NF/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/I2M_ELECTRON_NF/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/I2M_OXYGEN_NF/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F412ZG_NF/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F439ZI/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F439ZI/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F439ZI/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F439ZI/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoBooter/target_board.h.in
@@ -12,7 +12,6 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
 #define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/nanoCLR/target_board.h.in
@@ -12,7 +12,6 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
 #define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F401RE_NF/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/ST_STM32F411_DISCOVERY/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_STM32F411_DISCOVERY/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/ST_STM32F411_DISCOVERY/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_STM32F411_DISCOVERY/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */

--- a/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoBooter/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOBOOTER_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoBooter running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOBOOTER_H_ */

--- a/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/target_board.h.in
+++ b/CMSIS-OS/ChibiOS/ST_STM32F4_DISCOVERY/nanoCLR/target_board.h.in
@@ -12,8 +12,7 @@
 #define _TARGET_BOARD_NANOCLR_H_
 
 #include <target_common.h>
-#include <chversion.h>
 
-#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@ built with ChibiOS v" CH_VERSION "." STR(CH_VERSION_MONTH)
+#define OEMSYSTEMINFOSTRING "nanoCLR running @ @CHIBIOS_BOARD@"
 
 #endif /* _TARGET_BOARD_NANOCLR_H_ */


### PR DESCRIPTION
- OEM strings for all but the NUCLEO64-F411RE and TI_CC1352P1 boards are corrected.

***ALL***

Signed-off-by: piwi1263 <piwi1263@gmail.com>

