### PR TITLE
Remove custom phy from TI_CC1352P1_LAUNCHXL

### DIFF
--- a/TI-SimpleLink/TI_CC1352P1_LAUNCHXL/TI_CC1352P1_LAUNCHXL.syscfg
+++ b/TI-SimpleLink/TI_CC1352P1_LAUNCHXL/TI_CC1352P1_LAUNCHXL.syscfg
@@ -2,7 +2,7 @@
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
  * @cliArgs --board "/ti/boards/CC1352P1_LAUNCHXL" --product "simplelink_cc13x2_26x2_sdk@4.20.01.04"
- * @versions {"data":"2020052512","timestamp":"2020052512","tool":"1.5.0+1397","templates":"2020052512"}
+ * @versions {"data":"2020090214","timestamp":"2020090214","tool":"1.6.0+1543","templates":"2020090214"}
  */
 
 /**
@@ -36,8 +36,8 @@ easylink.EasyLink_Phy_50kbps2gfsk                                  = true;
 easylink.EasyLink_Phy_5kbpsSlLr                                    = true;
 easylink.EasyLink_Phy_200kbps2gfsk                                 = true;
 easylink.defaultPhy                                                = "EasyLink_Phy_5kbpsSlLr";
+easylink.EasyLink_Phy_Custom                                       = false;
 easylink.enableAddrFilter                                          = false;
-easylink.radioConfigEasylinkPhyCustom.codeExportConfig.$name       = "ti_devices_radioconfig_code_export_param0";
 easylink.radioConfigEasylinkPhy50kbps2gfsk.codeExportConfig.$name  = "ti_devices_radioconfig_code_export_param1";
 easylink.radioConfigEasylinkPhy5kbpssllr.codeExportConfig.$name    = "ti_devices_radioconfig_code_export_param2";
 easylink.radioConfigEasylinkPhy200kbps2gfsk.codeExportConfig.$name = "ti_devices_radioconfig_code_export_param3";


### PR DESCRIPTION
## Description.
- Remove custom phy from TI_CC1352P1_LAUNCHXL.
***TI_CC1352P1_LAUNCHXL***

## Motivation and Context
- Improvements from new SysConfig tool.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
