### PR TITLE
Fix initialization of network config block

### DIFF
--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F439ZI/common/targetHAL_ConfigurationManager.cpp
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F439ZI/common/targetHAL_ConfigurationManager.cpp
@@ -14,13 +14,16 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 {
     (void)configurationIndex;
 
+    // zero memory
+    memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
+
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
     
     pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;
-    pconfig->SpecificConfigId = 0;
+    pconfig->SpecificConfigId = UINT32_MAX;
 
     // set MAC address with ST provided MAC for development boards
     // 00:80:E1:01:35:D1

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/common/targetHAL_ConfigurationManager.cpp
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO144_F746ZG/common/targetHAL_ConfigurationManager.cpp
@@ -14,13 +14,16 @@ bool InitialiseNetworkDefaultConfig(HAL_Configuration_NetworkInterface * pconfig
 {
     (void)configurationIndex;
 
+    // zero memory
+    memset(pconfig, 0, sizeof(HAL_Configuration_NetworkInterface));
+
     // make sure the config block marker is set
     memcpy(pconfig->Marker, c_MARKER_CONFIGURATION_NETWORK_V1, sizeof(c_MARKER_CONFIGURATION_NETWORK_V1));
     
     pconfig->InterfaceType = NetworkInterfaceType_Ethernet;
     pconfig->StartupAddressMode = AddressMode_DHCP;
     pconfig->AutomaticDNS = 1;
-    pconfig->SpecificConfigId = 0;
+    pconfig->SpecificConfigId = UINT32_MAX;
 
     // set MAC address with ST provided MAC for development boards
     // 00:80:E1:01:35:D1


### PR DESCRIPTION
## Description
- Missing zeroing the memory.
- The specific config ID was being, wrongly, set to 0.

***ST_NUCLEO144_F439ZI***
***ST_NUCLEO144_F746ZG***

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
