### PR TITLE
Add tamplatest for BrainPad2 and Nucleo F411RE

### DIFF
--- a/CMSIS-OS/ChibiOS/BrainPad2/cmake-variants.json
+++ b/CMSIS-OS/ChibiOS/BrainPad2/cmake-variants.json
@@ -1,0 +1,67 @@
+{
+  "buildType": {
+    "default": "debug",
+    "choices": {
+      "debug": {
+        "short": "Debug",
+        "long": "Emit debug information without performing optimizations",
+        "buildType": "Debug"
+      },
+      "minsize": {
+        "short": "MinSizeRel",
+        "long": "Optimize for smallest binary size",
+        "buildType": "MinSizeRel"
+      },
+      "reldeb": {
+        "short": "RelWithDebInfo",
+        "long": "Perform optimizations AND include debugging information",
+        "buildType": "RelWithDebInfo"
+      }
+    }
+  },
+  "linkage": {
+    "default": "",
+    "choices": {
+      "BrainPad2": {
+        "short": "BrainPad2",
+        "settings": {
+          "BUILD_VERSION": "0.9.99.999",
+          "CMAKE_TOOLCHAIN_FILE" : "CMake/toolchain.arm-none-eabi.cmake",
+          "TOOLCHAIN_PREFIX": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>",
+          "TOOL_HEX2DFU_PREFIX": "<absolute-path-to-hex2dfu-mind-the-forward-slashes>",
+          "RTOS": "CHIBIOS",
+          "TARGET_SERIES": "STM32F4xx",
+          "RTOS_SOURCE_FOLDER": "",
+          "CHIBIOS_BOARD": "BrainPad2",
+          "CHIBIOS_CONTRIB_REQUIRED": "OFF",
+          "CHIBIOS_CONTRIB_SOURCE": "",
+          "STM32_CUBE_PACKAGE_REQUIRED": "OFF",
+          "STM32_CUBE_PACKAGE_SOURCE": "",
+          "MBEDTLS_SOURCE": "",
+          "SUPPORT_ANY_BASE_CONVERSION": "OFF",
+          "NF_FEATURE_DEBUGGER": "ON",
+          "NF_FEATURE_RTC": "ON",
+          "NF_FEATURE_HAS_SDCARD": "OFF",
+          "SWO_OUTPUT": "OFF",
+          "NF_BUILD_RTM": "OFF",
+          "API_System.Math": "ON",
+          "API_Hardware.Stm32": "ON",
+          "API_Windows.Devices.Gpio": "ON",
+          "API_System.Device.Gpio": "ON",
+          "API_Windows.Devices.Spi": "ON",
+          "API_Windows.Devices.I2c": "ON",
+          "API_System.Device.I2c": "ON",
+          "API_Windows.Devices.Pwm": "ON",
+          "API_Windows.Devices.SerialCommunication": "ON",
+          "API_Windows.Devices.Adc": "ON",
+		  "API_Windows.Devices.Dac": "OFF",
+          "API_nanoFramework.Devices.OneWire": "OFF",
+		  "API_nanoFramework.Devices.Can": "OFF",
+          "API_nanoFramework.ResourceManager": "ON",
+          "API_nanoFramework.System.Collections": "ON",
+          "API_nanoFramework.System.Text": "ON"
+        }
+      }
+    }
+  }
+}

--- a/CMSIS-OS/ChibiOS/BrainPad2/launch.json
+++ b/CMSIS-OS/ChibiOS/BrainPad2/launch.json
@@ -1,0 +1,115 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "BrainPad2 nanoBooter",
+            "type": "cppdbg",
+            "request": "launch",
+            "miDebuggerPath": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>/bin/arm-none-eabi-gdb.exe",
+            "targetArchitecture": "ARM",
+            "program": "${workspaceRoot}/build/nanoBooter.elf",
+            "setupCommands": [
+                {
+                    "text": "target extended-remote localhost:3333"
+                },
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "monitor flash write_image erase \"<path-to-the-repo-root-mind-the-forward-slash>/build/nanoBooter.hex\" "
+                },
+                {
+                    "text": "file <path-to-the-repo-root-mind-the-forward-slash>/build/nanoBooter.elf"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "set output-radix 16",
+                    "description": "set the default numeric base to 16",
+                    "ignoreFailures": false
+                }
+            ],
+            "customLaunchSetupCommands": [
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                }
+            ],
+            "logging": {
+                "moduleLoad": false,
+                "trace": false,
+                "engineLogging": false,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "launchCompleteCommand": "exec-continue",
+            "debugServerPath": "<absolute-path-to-openocd-mind-the-forward-slashes>/bin/openocd.exe",
+            "debugServerArgs": "-s \"<absolute-path-to-openocd-mind-the-forward-slashes>/scripts/\" -f board/st_nucleo_f4.cfg",
+            "serverStarted": "Info\\ :\\ [\\w\\d\\.]*:\\ hardware",
+            "filterStderr": true,
+            "externalConsole": true,
+            "cwd": "${cwd}"
+        },
+        {
+            "name": "BrainPad2 nanoCLR",
+            "type": "cppdbg",
+            "request": "launch",
+            "miDebuggerPath": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>/bin/arm-none-eabi-gdb.exe",
+            "targetArchitecture": "ARM",
+            "program": "${workspaceRoot}/build/nanoCLR.elf",
+            "setupCommands": [
+                {
+                    "text": "target extended-remote localhost:3333"
+                },
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "monitor flash write_image erase \"<path-to-the-repo-root-mind-the-forward-slash>/build/nanoCLR.hex\" "
+                },
+                {
+                    "text": "file <path-to-the-repo-root-mind-the-forward-slash>/build/nanoCLR.elf"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "set output-radix 16",
+                    "description": "set the default numeric base to 16",
+                    "ignoreFailures": false
+                }
+            ],
+            "customLaunchSetupCommands": [
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                }
+            ],
+            "logging": {
+                "moduleLoad": false,
+                "trace": false,
+                "engineLogging": false,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "launchCompleteCommand": "exec-continue",
+            "debugServerPath": "<absolute-path-to-openocd-mind-the-forward-slashes>/bin/openocd.exe",
+            "debugServerArgs": "-s \"<absolute-path-to-openocd-mind-the-forward-slashes>/scripts/\" -f board/st_nucleo_f4.cfg",
+            "serverStarted": "Info\\ :\\ [\\w\\d\\.]*:\\ hardware",
+            "filterStderr": true,
+            "externalConsole": true,
+            "cwd": "${cwd}"
+        }
+    ]
+}

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/cmake-variants.json
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/cmake-variants.json
@@ -1,0 +1,67 @@
+{
+  "buildType": {
+    "default": "debug",
+    "choices": {
+      "debug": {
+        "short": "Debug",
+        "long": "Emit debug information without performing optimizations",
+        "buildType": "Debug"
+      },
+      "minsize": {
+        "short": "MinSizeRel",
+        "long": "Optimize for smallest binary size",
+        "buildType": "MinSizeRel"
+      },
+      "reldeb": {
+        "short": "RelWithDebInfo",
+        "long": "Perform optimizations AND include debugging information",
+        "buildType": "RelWithDebInfo"
+      }
+    }
+  },
+  "linkage": {
+    "default": "",
+    "choices": {
+         "ST_NUCLEO64_F411RE_NF" : {
+          "short" : "ST_NUCLEO64_F411RE_NF",
+          "settings" : {
+          "BUILD_VERSION": "0.9.99.999",
+          "CMAKE_TOOLCHAIN_FILE": "CMake/toolchain.arm-none-eabi.cmake",
+          "TOOLCHAIN_PREFIX": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>",
+          "TOOL_HEX2DFU_PREFIX": "<absolute-path-to-hex2dfu-mind-the-forward-slashes>",
+          "RTOS": "CHIBIOS",
+          "TARGET_SERIES": "STM32F4xx",
+          "RTOS_SOURCE_FOLDER": "",
+          "CHIBIOS_BOARD": "ST_NUCLEO64_F411RE_NF",
+          "CHIBIOS_CONTRIB_REQUIRED": "OFF",
+          "CHIBIOS_CONTRIB_SOURCE": "",
+          "STM32_CUBE_PACKAGE_REQUIRED": "OFF",
+          "STM32_CUBE_PACKAGE_SOURCE": "",
+          "USE_RNG" : "OFF",
+          "DP_FLOATINGPOINT" : "OFF",
+          "SUPPORT_ANY_BASE_CONVERSION" : "OFF",
+          "NF_FEATURE_DEBUGGER": "ON",
+          "NF_FEATURE_RTC": "ON",
+          "SWO_OUTPUT": "OFF",
+          "NF_BUILD_RTM": "OFF",
+          "API_System.Math": "ON",
+          "API_Hardware.Stm32": "ON",
+          "API_Windows.Devices.Gpio": "ON",
+          "API_System.Device.Gpio": "ON",
+          "API_Windows.Devices.Spi": "ON",
+          "API_Windows.Devices.I2c": "ON",
+          "API_System.Device.I2c": "ON",
+          "API_Windows.Devices.Pwm": "ON",
+          "API_Windows.Devices.SerialCommunication": "ON",
+          "API_Windows.Devices.Adc": "ON",
+		  "API_Windows.Devices.Dac": "OFF",
+          "API_nanoFramework.Devices.OneWire": "OFF",
+          "API_nanoFramework.Devices.Can": "OFF",
+          "API_nanoFramework.ResourceManager": "ON",
+          "API_nanoFramework.System.Collections": "ON",
+          "API_nanoFramework.System.Text": "ON"
+        }
+      }
+    }
+  }
+}

--- a/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/launch.json
+++ b/CMSIS-OS/ChibiOS/ST_NUCLEO64_F411RE_NF/launch.json
@@ -1,0 +1,115 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "ST_NUCLEO64_F411RE_NF nanoBooter",
+            "type": "cppdbg",
+            "request": "launch",
+            "miDebuggerPath": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>/bin/arm-none-eabi-gdb.exe",
+            "targetArchitecture": "ARM",
+            "program": "${workspaceRoot}/build/nanoBooter.elf",
+            "setupCommands": [
+                {
+                    "text": "target extended-remote localhost:3333"
+                },
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "monitor flash write_image erase \"<path-to-the-repo-root-mind-the-forward-slash>/build/nanoBooter.hex\" "
+                },
+                {
+                    "text": "file <path-to-the-repo-root-mind-the-forward-slash>/build/nanoBooter.elf"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "set output-radix 16",
+                    "description": "set the default numeric base to 16",
+                    "ignoreFailures": false
+                }
+            ],
+            "customLaunchSetupCommands": [
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                }
+            ],
+            "logging": {
+                "moduleLoad": false,
+                "trace": false,
+                "engineLogging": false,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "launchCompleteCommand": "exec-continue",
+            "debugServerPath": "<absolute-path-to-openocd-mind-the-forward-slashes>/bin/openocd.exe",
+            "debugServerArgs": "-s \"<absolute-path-to-openocd-mind-the-forward-slashes>/scripts/\" -f board/st_nucleo_f4.cfg",
+            "serverStarted": "Info\\ :\\ [\\w\\d\\.]*:\\ hardware",
+            "filterStderr": true,
+            "externalConsole": true,
+            "cwd": "${cwd}"
+        },
+        {
+            "name": "ST_NUCLEO64_F411RE_NF nanoCLR",
+            "type": "cppdbg",
+            "request": "launch",
+            "miDebuggerPath": "<absolute-path-to-the-toolchain-folder-mind-the-forward-slashes>/bin/arm-none-eabi-gdb.exe",
+            "targetArchitecture": "ARM",
+            "program": "${workspaceRoot}/build/nanoCLR.elf",
+            "setupCommands": [
+                {
+                    "text": "target extended-remote localhost:3333"
+                },
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "monitor flash write_image erase \"<path-to-the-repo-root-mind-the-forward-slash>/build/nanoCLR.hex\" "
+                },
+                {
+                    "text": "file <path-to-the-repo-root-mind-the-forward-slash>/build/nanoCLR.elf"
+                },
+                {
+                    "text": "monitor reset halt"
+                },
+                {
+                    "text": "set output-radix 16",
+                    "description": "set the default numeric base to 16",
+                    "ignoreFailures": false
+                }
+            ],
+            "customLaunchSetupCommands": [
+                {
+                    "text": "monitor reset_config none separate"
+                },
+                {
+                    "text": "monitor reset halt"
+                }
+            ],
+            "logging": {
+                "moduleLoad": false,
+                "trace": false,
+                "engineLogging": false,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "launchCompleteCommand": "exec-continue",
+            "debugServerPath": "<absolute-path-to-openocd-mind-the-forward-slashes>/bin/openocd.exe",
+            "debugServerArgs": "-s \"<absolute-path-to-openocd-mind-the-forward-slashes>/scripts/\" -f board/st_nucleo_f4.cfg",
+            "serverStarted": "Info\\ :\\ [\\w\\d\\.]*:\\ hardware",
+            "filterStderr": true,
+            "externalConsole": true,
+            "cwd": "${cwd}"
+        }
+    ]
+}


### PR DESCRIPTION
## Description
- Add cmake variants and launch templates for BrainPad2 and Nucleo F411RE.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
