### PR TITLE
Upgrade CICD build image to VS2019.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
 ##############################
 - job: Get_Commit_Message
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   steps:
   - checkout: self
@@ -89,7 +89,7 @@ jobs:
 ##############################
 - job: Check_Build_Options
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   dependsOn: 
   - Get_Commit_Message
@@ -189,7 +189,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: MBN_QUAIL
@@ -226,7 +226,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: GHI_FEZ_CERB40_NF
@@ -263,7 +263,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: I2M_ELECTRON_NF
@@ -300,7 +300,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: I2M_OXYGEN_NF
@@ -337,7 +337,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_NUCLEO64_F401RE_NF
@@ -374,7 +374,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_NUCLEO64_F411RE_NF
@@ -411,7 +411,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_STM32F411_DISCOVERY
@@ -448,7 +448,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_NUCLEO144_F412ZG_NF
@@ -485,7 +485,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_NUCLEO144_F746ZG
@@ -522,7 +522,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_STM32F4_DISCOVERY
@@ -559,7 +559,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: ST_NUCLEO144_F439ZI
@@ -596,7 +596,7 @@ jobs:
   - Check_Build_Options
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   variables:
     TargetBoard: TI_CC1352P1_LAUNCHXL
@@ -642,7 +642,7 @@ jobs:
   condition: or( failed('Build_GHI_FEZ_CERB40_NF'), failed('Build_I2M_ELECTRON_NF'), failed('Build_I2M_OXYGEN_NF'), failed('Build_ST_NUCLEO64_F401RE_NF'), failed('Build_ST_NUCLEO64_F411RE_NF'), failed('Build_ST_STM32F411_DISCOVERY'), failed('Build_ST_NUCLEO144_F412ZG_NF'), failed('Build_ST_NUCLEO144_F746ZG'), failed('Build_ST_STM32F4_DISCOVERY'), failed('Build_ST_NUCLEO144_F439ZI'), failed('Build_TI_CC1352P1_LAUNCHXL'))
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   steps:
   - checkout: self


### PR DESCRIPTION
## Description
CICD currently uses VS2017. VS2019 will be required in future, so we should update if possible

## Motivation and Context
Ensures that we dont get caught out by azure-pipelines removing VS2017 as a valid image.
- Resolves nanoframework/Home#667

## How Has This Been Tested?

## Screenshots

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
