### PR TITLE
Fix cmake variants template for ST_NUCLEO144_F746ZG

### DIFF
--- a/ChibiOS/ST_NUCLEO144_F746ZG/cmake-variants.json
+++ b/ChibiOS/ST_NUCLEO144_F746ZG/cmake-variants.json
@@ -58,7 +58,7 @@
           "NF_FEATURE_USE_APPDOMAINS": "OFF",
           "NF_FEATURE_WATCHDOG": "ON",
           "NF_FEATURE_HAS_CONFIG_BLOCK": "ON",
-          "NF_FEATURE_HAS_SDCARD": "ON",
+          "NF_FEATURE_HAS_SDCARD": "OFF",
           "NF_FEATURE_HAS_USB_MSD": "OFF",
           "NF_FEATURE_USE_SPIFFS": "OFF",
           "NF_PLATFORM_NO_CLR_TRACE": "OFF",


### PR DESCRIPTION
## Description
Fix F746ZG local build option in cmake-variants.json file as it was incorrectly using SDCard which is unsupported.

## Targets affected
- [ ] BrainPad2
- [ ] GHI_FEZ_CERB40_NF
- [ ] I2M_ELECTRON_NF
- [ ] I2M_OXYGEN_NF
- [ ] MBN_QUAIL
- [ ] NETDUINO3_WIFI
- [ ] PybStick2x
- [ ] ST_NUCLEO64_F401RE_NF
- [ ] ST_NUCLEO64_F411RE_NF
- [ ] ST_STM32F411_DISCOVERY
- [ ] ST_NUCLEO144_F412ZG_NF
- [x] ST_NUCLEO144_F746ZG
- [ ] ST_STM32F4_DISCOVERY
- [ ] ST_NUCLEO144_F439ZI
- [ ] WEACT_F411CE
- [ ] TI_CC1352P1_LAUNCHXL_868
- [ ] TI_CC1352P1_LAUNCHXL_915
- [ ] BUILD ALL

## Motivation and Context

## How Has This Been Tested?<!-- (if applicable) -->
Tested build locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
