### PR TITLE
Fix issue with USB CDC at reboot

### DIFF
--- a/ChibiOS/NESHTEC_NESHNODE_V1/nanoCLR/main.c
+++ b/ChibiOS/NESHTEC_NESHNODE_V1/nanoCLR/main.c
@@ -25,7 +25,7 @@ osThreadDef(CLRStartupThread, osPriorityNormal, 4096, "CLRStartupThread");
 //  Application entry point.
 int main(void)
 {
-        // find out wakeup reason
+    // find out wakeup reason
     if ((PWR->CSR1 & PWR_CSR1_WUIF) == PWR_CSR1_WUIF)
     {
         // standby, match WakeupReason_FromStandby enum
@@ -74,17 +74,6 @@ int main(void)
     crcStart(NULL);
 #endif
 
-    //  Initializes a serial-over-USB CDC driver.
-    sduObjectInit(&SDU1);
-    sduStart(&SDU1, &serusbcfg);
-
-    // Activates the USB driver and then the USB bus pull-up on D+.
-    // Note, a delay is inserted in order to not have to disconnect the cable after a reset
-    usbDisconnectBus(serusbcfg.usbp);
-    chThdSleepMilliseconds(100);
-    usbStart(serusbcfg.usbp, &usbcfg);
-    usbConnectBus(serusbcfg.usbp);
-
     // create the receiver thread
     osThreadCreate(osThread(ReceiverThread), NULL);
 
@@ -107,4 +96,18 @@ int main(void)
         // palToggleLine(LINE_LD2);
         osDelay(100);
     }
+}
+
+void WP_Message_PrepareReception_Target()
+{
+    //  Initializes a serial-over-USB CDC driver.
+    sduObjectInit(&SDU1);
+    sduStart(&SDU1, &serusbcfg);
+
+    // Activates the USB driver and then the USB bus pull-up on D+.
+    // Note, a delay is inserted in order to not have to disconnect the cable after a reset
+    usbDisconnectBus(serusbcfg.usbp);
+    chThdSleepMilliseconds(100);
+    usbStart(serusbcfg.usbp, &usbcfg);
+    usbConnectBus(serusbcfg.usbp);
 }


### PR DESCRIPTION
## Description
- Move USB CDC init code to WP prep handler.

## Targets affected
<!--- Check the targets that are affected in the list below -->
<!--- If the change(s) apply to all targets just check the ALL option -->
<!--- Not choosing which targets the PR affects will cause the PR to be closed immediately -->
- [ ] BrainPad2
- [ ] GHI_FEZ_CERB40_NF
- [ ] GHI_FEZ_CERBERUS_NF
- [ ] I2M_ELECTRON_NF
- [ ] I2M_OXYGEN_NF
- [ ] MBN_QUAIL
- [x] NESHTEC_NESHNODE_V1
- [ ] NETDUINO3_WIFI
- [ ] PybStick2x
- [ ] ST_NUCLEO64_F401RE_NF
- [ ] ST_NUCLEO64_F411RE_NF
- [ ] ST_STM32F411_DISCOVERY
- [ ] ST_NUCLEO144_F412ZG_NF
- [ ] ST_NUCLEO144_F746ZG
- [ ] ST_STM32F4_DISCOVERY
- [ ] ST_NUCLEO144_F439ZI
- [ ] WEACT_F411CE
- [ ] TI_CC1352P1_LAUNCHXL_868
- [ ] TI_CC1352P1_LAUNCHXL_915
- [ ] LilygoTWatch2020
- [ ] LilygoTWatch2021
- [ ] BUILD ALL

## Motivation and Context
- Fixes issue with board reboot not always properly enumerating USB CDC device.

## How Has This Been Tested?<!-- (if applicable) -->
- Successive reboot on VS after debug and without debug session.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
