### PR TITLE
Remove Windows.Storage from pybstick2x

### DIFF
--- a/ChibiOS/PybStick2x/CMakePresets.json
+++ b/ChibiOS/PybStick2x/CMakePresets.json
@@ -30,7 +30,6 @@
                 "NF_FEATURE_HAS_CONFIG_BLOCK": "OFF",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "NF_FEATURE_HAS_USB_MSD": "OFF",
-                "NF_FEATURE_HAS_ACCESSIBLE_STORAGE": "ON", 
                 "NF_NETWORKING_SNTP": "OFF",
                 "API_Hardware.Stm32": "ON",
                 "API_nanoFramework.Device.Can": "OFF",
@@ -42,7 +41,7 @@
                 "API_System.Device.I2c": "ON",
                 "API_System.IO.Ports": "ON",
                 "API_System.Device.Spi": "ON",
-                "API_System.IO.FileSystem": "ON",
+                "API_System.IO.FileSystem": "OFF",
                 "API_nanoFramework.System.Text": "ON"
             }
         }

--- a/ChibiOS/PybStick2x/CMakePresets.json
+++ b/ChibiOS/PybStick2x/CMakePresets.json
@@ -42,7 +42,6 @@
                 "API_System.IO.Ports": "ON",
                 "API_System.Device.Spi": "ON",
                 "API_System.IO.FileSystem": "ON",
-                "API_Windows.Storage": "ON",
                 "API_nanoFramework.System.Text": "ON"
             }
         }

--- a/ChibiOS/PybStick2x/CMakePresets.json
+++ b/ChibiOS/PybStick2x/CMakePresets.json
@@ -30,7 +30,7 @@
                 "NF_FEATURE_HAS_CONFIG_BLOCK": "OFF",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "NF_FEATURE_HAS_USB_MSD": "OFF",
-                "NF_FEATURE_USE_FILESYSTEM": "ON",
+                "NF_FEATURE_HAS_ACCESSIBLE_STORAGE": "ON", 
                 "NF_NETWORKING_SNTP": "OFF",
                 "API_Hardware.Stm32": "ON",
                 "API_nanoFramework.Device.Can": "OFF",

--- a/ChibiOS/PybStick2x/CMakePresets.json
+++ b/ChibiOS/PybStick2x/CMakePresets.json
@@ -30,6 +30,7 @@
                 "NF_FEATURE_HAS_CONFIG_BLOCK": "OFF",
                 "NF_FEATURE_HAS_SDCARD": "ON",
                 "NF_FEATURE_HAS_USB_MSD": "OFF",
+                "NF_FEATURE_USE_FILESYSTEM": "ON",
                 "NF_NETWORKING_SNTP": "OFF",
                 "API_Hardware.Stm32": "ON",
                 "API_nanoFramework.Device.Can": "OFF",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Win.storage is deprecated will not work.
Also turns off `API_System.IO.FileSystem`until it can be fixed.

## Targets affected
<!--- Check the targets that are affected in the list below -->
<!--- If the change(s) apply to all targets just check the ALL option -->
<!--- Not choosing which targets the PR affects will cause the PR to be closed immediately -->
- [ ] BrainPad2
- [ ] GHI_FEZ_CERB40_NF
- [ ] GHI_FEZ_CERBERUS_NF
- [ ] I2M_ELECTRON_NF
- [ ] I2M_OXYGEN_NF
- [ ] MBN_QUAIL
- [ ] NESHTEC_NESHNODE_V1
- [ ] NETDUINO3_WIFI
- [x] PybStick2x
- [ ] ST_NUCLEO64_F401RE_NF
- [ ] ST_NUCLEO64_F411RE_NF
- [ ] ST_STM32F411_DISCOVERY
- [ ] ST_NUCLEO144_F412ZG_NF
- [ ] ST_NUCLEO144_F746ZG
- [ ] ST_STM32F4_DISCOVERY
- [ ] ST_NUCLEO144_F439ZI
- [ ] WEACT_F411CE
- [ ] TI_CC1352P1_LAUNCHXL_868
- [ ] TI_CC1352P1_LAUNCHXL_915
- [ ] LilygoTWatch2020
- [ ] LilygoTWatch2021
- [ ] BUILD ALL

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
Remove deprecated API.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated project configuration by removing support for the Windows-specific storage API, streamlining platform-specific dependencies.
	- Enabled filesystem support in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->